### PR TITLE
Get rid of pushd and popd due to issue #67

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -134,29 +134,29 @@ for:
       - BUNDLE_NAME=libpythonbundle.so
 
       # arm64-v8a
-      - pushd ~/.local/share/python-for-android/dists/serious_python/_python_bundle__arm64-v8a/_python_bundle
+      - cd ~/.local/share/python-for-android/dists/serious_python/_python_bundle__arm64-v8a/_python_bundle
       - zip -r $BUNDLE_NAME .
       - mv $BUNDLE_NAME ../../libs/arm64-v8a
-      - popd
+      - cd -
 
       # armeabi-v7a
-      - pushd ~/.local/share/python-for-android/dists/serious_python/_python_bundle__armeabi-v7a/_python_bundle
+      - cd ~/.local/share/python-for-android/dists/serious_python/_python_bundle__armeabi-v7a/_python_bundle
       - zip -r $BUNDLE_NAME .
       - mv $BUNDLE_NAME ../../libs/armeabi-v7a
-      - popd
+      - cd -
 
       # armeabi-v7a
-      - pushd ~/.local/share/python-for-android/dists/serious_python/_python_bundle__x86_64/_python_bundle
+      - cd ~/.local/share/python-for-android/dists/serious_python/_python_bundle__x86_64/_python_bundle
       - zip -r $BUNDLE_NAME .
       - mv $BUNDLE_NAME ../../libs/x86_64
-      - popd
+      - cd -
 
       # package all .so files
       - DIST_FILE_NAME=python-android-dist-v$APPVEYOR_BUILD_VERSION.tar.gz
-      - pushd ~/.local/share/python-for-android/dists/serious_python/libs
+      - cd ~/.local/share/python-for-android/dists/serious_python/libs
       - tar -czvf $DIST_FILE_NAME *
       - appveyor PushArtifact $DIST_FILE_NAME -DeploymentName python-dist-android
-      - popd
+      - cd -
 
     deploy:
       provider: GitHub
@@ -382,55 +382,55 @@ for:
             python3 ci/patch_pubspec.py src/serious_python_windows/pubspec.yaml $PKG_VER
             python3 ci/patch_pubspec.py src/serious_python_linux/pubspec.yaml $PKG_VER
 
-            pushd src/serious_python_platform_interface
+            cd src/serious_python_platform_interface
             dart pub publish --force || exit 1
-            popd
+            cd -
 
-            pushd src/serious_python_android
+            cd src/serious_python_android
             dart pub publish --force || exit 1
-            popd
+            cd -
 
-            pushd src/serious_python_darwin
+            cd src/serious_python_darwin
             dart pub publish --force || exit 1
-            popd
+            cd -
 
-            pushd src/serious_python_windows
+            cd src/serious_python_windows
             dart pub publish --force || exit 1
-            popd
+            cd -
 
-            pushd src/serious_python_linux
+            cd src/serious_python_linux
             dart pub publish --force || exit 1
-            popd
+            cd -
 
-            pushd src/serious_python
+            cd src/serious_python
             dart pub publish --force || exit 1
-            popd
+            cd -
 
           elif [[ "$APPVEYOR_PULL_REQUEST_NUMBER" == "" ]]; then
 
-            pushd src/serious_python_platform_interface
+            cd src/serious_python_platform_interface
             dart pub publish --dry-run
-            popd
+            cd -
 
-            pushd src/serious_python_android
+            cd src/serious_python_android
             dart pub publish --dry-run
-            popd
+            cd -
 
-            pushd src/serious_python_darwin
+            cd src/serious_python_darwin
             dart pub publish --dry-run
-            popd
+            cd -
 
-            pushd src/serious_python_windows
+            cd src/serious_python_windows
             dart pub publish --dry-run
-            popd
+            cd -
 
-            pushd src/serious_python_linux
+            cd src/serious_python_linux
             dart pub publish --dry-run
-            popd
+            cd -
 
-            pushd src/serious_python
+            cd src/serious_python
             dart pub publish --dry-run
-            popd
+            cd -
           fi
 
     test: off

--- a/src/serious_python_android/android/bundle.sh
+++ b/src/serious_python_android/android/bundle.sh
@@ -14,22 +14,22 @@ rm -rf $JNI_LIBS_DIR
 mkdir -p $JNI_LIBS_DIR
 
 echo "Bundling arm64-v8a"
-pushd $SERIOUS_PYTHON_P4A_DIST/_python_bundle__arm64-v8a/_python_bundle
+cd $SERIOUS_PYTHON_P4A_DIST/_python_bundle__arm64-v8a/_python_bundle
 zip -r $BUNDLE_NAME . > /dev/null
 mv $BUNDLE_NAME ../../libs/arm64-v8a
-popd
+cd -
 
 echo "Bundling armeabi-v7a"
-pushd $SERIOUS_PYTHON_P4A_DIST/_python_bundle__armeabi-v7a/_python_bundle
+cd $SERIOUS_PYTHON_P4A_DIST/_python_bundle__armeabi-v7a/_python_bundle
 zip -r $BUNDLE_NAME . > /dev/null
 mv $BUNDLE_NAME ../../libs/armeabi-v7a
-popd
+cd -
 
 echo "Bundling armeabi-v7a"
-pushd $SERIOUS_PYTHON_P4A_DIST/_python_bundle__x86_64/_python_bundle
+cd $SERIOUS_PYTHON_P4A_DIST/_python_bundle__x86_64/_python_bundle
 zip -r $BUNDLE_NAME . > /dev/null
 mv $BUNDLE_NAME ../../libs/x86_64
-popd
+cd -
 
 echo "Copying all .so files to `realpath $JNI_LIBS_DIR`"
 cp -R $SERIOUS_PYTHON_P4A_DIST/libs/* $JNI_LIBS_DIR

--- a/src/serious_python_darwin/darwin/serious_python_darwin.podspec
+++ b/src/serious_python_darwin/darwin/serious_python_darwin.podspec
@@ -62,33 +62,33 @@ Pod::Spec.new do |s|
     cp #{python_framework}/ios-arm64/Headers/module.modulemap #{python_macos_framework}/macos-arm64_x86_64/Headers
 
     # compile dist_macos/python-stdlib
-    pushd dist_macos/python-stdlib
+    cd dist_macos/python-stdlib
     $ROOT/dist/hostpython3/bin/python -m compileall -b .
     find . \\( -name '*.py' -or -name '*.typed' \\) -type f -delete
     rm -rf __pycache__
     rm -rf **/__pycache__
-    popd
+    cd -
 
     # compile python311.zip
     PYTHON311_ZIP=$ROOT/dist/root/python3/lib/python311.zip
     unzip $PYTHON311_ZIP -d python311_temp
     rm $PYTHON311_ZIP
-    pushd python311_temp
+    cd python311_temp
     $ROOT/dist/hostpython3/bin/python -m compileall -b .
     find . \\( -name '*.so' -or -name '*.py' -or -name '*.typed' \\) -type f -delete
     zip -r $PYTHON311_ZIP .
-    popd
+    cd -
     rm -rf python311_temp
 
     # fix import subprocess, asyncio
     cp -R pod_templates/site-packages/* dist/root/python3/lib/python3.11/site-packages
 
     # zip site-packages
-    pushd dist/root/python3/lib/python3.11/site-packages
+    cd dist/root/python3/lib/python3.11/site-packages
     $ROOT/dist/hostpython3/bin/python -m compileall -b .
     find . \\( -name '*.so' -or -name '*.py' -or -name '*.typed' \\) -type f -delete
     zip -r $ROOT/dist/root/python3/lib/site-packages.zip .
-    popd
+    cd -
   
     # remove junk
     rm -rf dist/root/python3/lib/python3.11


### PR DESCRIPTION
Close #67 

I changed all `pushd` to `cd` and `popd` to `cd -` to get rid of `pushd` and `popd` at call due to issue #67.

The `cd -` command in the Unix/Linux shell is a shortcut for changing the directory to the previous working directory. It essentially switches you back to the directory you were in before the last `cd` command you executed.

For example, if you were in directory `/home/user/Documents` and you executed `cd /var/www`, then running `cd -` would take you back to `/home/user/Documents`. 

This can be quite handy for toggling between two directories without having to type out their full paths each time.