### PR TITLE
[Windows] Script set as empty string to fix windows build error

### DIFF
--- a/src/serious_python/lib/serious_python.dart
+++ b/src/serious_python/lib/serious_python.dart
@@ -64,6 +64,7 @@ class SeriousPython {
     return runProgram(appPath,
         modulePaths: modulePaths,
         environmentVariables: environmentVariables,
+        script: Platform.isWindows ? "" : null,
         sync: sync);
   }
 


### PR DESCRIPTION
I and some other users were facing this issue https://github.com/flet-dev/serious-python/issues/70 
@jackie099 suggetsed this fix https://github.com/flet-dev/serious-python/issues/70#issuecomment-2003101694
Here is the PR for the same.