### PR TITLE
Bump Python version to Python 3.12.6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -122,7 +122,7 @@ for:
       - echo "y" | sdkmanager --install "platforms;$SDK_VERSION" > /dev/null
 
       # install Kivy for Android
-      - pip3 install git+https://github.com/flet-dev/python-for-android.git@3.11.6
+      - pip3 install git+https://github.com/flet-dev/python-for-android.git@3.12.6
       - pip3 install --upgrade cython
       - p4a --help
       - p4a create --requirements python3 --arch arm64-v8a --arch armeabi-v7a --arch x86_64 --sdk-dir $ANDROID_SDK_ROOT --ndk-dir $ANDROID_SDK_ROOT/ndk/$NDK_VERSION --dist-name serious_python

--- a/src/serious_python/README.md
+++ b/src/serious_python/README.md
@@ -16,11 +16,11 @@ Serious Python is part of [Flet](https://flet.dev) project - the fastest way to 
 
 ### Python versions
 
-* iOS: Python 3.11.6 - based on [Kivy toolchain](https://github.com/kivy/kivy-ios).
-* Android: Python 3.11.6 - based on [Kivy python-for-android](https://github.com/kivy/python-for-android).
-* macOS: Python 3.11.6 - based on [Beeware's Python Apple Support](https://github.com/beeware/Python-Apple-support).
-* Linux: Python 3.11.6 - based on [indygreg/python-build-standalone](https://github.com/indygreg/python-build-standalone).
-* Windows: Python 3.11.6 - based on [CPython](https://www.python.org/downloads/release/python-3116/).
+* iOS: Python 3.12.6 - based on [Kivy toolchain](https://github.com/kivy/kivy-ios).
+* Android: Python 3.12.6 - based on [Kivy python-for-android](https://github.com/kivy/python-for-android).
+* macOS: Python 3.12.6 - based on [Beeware's Python Apple Support](https://github.com/beeware/Python-Apple-support).
+* Linux: Python 3.12.6 - based on [indygreg/python-build-standalone](https://github.com/indygreg/python-build-standalone).
+* Windows: Python 3.12.6 - based on [CPython](https://www.python.org/downloads/release/python-3126/).
 
 ## Usage
 

--- a/src/serious_python/bin/package_command.dart
+++ b/src/serious_python/bin/package_command.dart
@@ -443,7 +443,7 @@ class PackageCommand extends Command {
   Future<int> runPython(List<String> args,
       {Map<String, String>? environment}) async {
     if (_pythonDir == null) {
-      _pythonDir = await Directory.systemTemp.createTemp('hostpython3.11_');
+      _pythonDir = await Directory.systemTemp.createTemp('hostpython3.12_');
 
       var isArm64 = Platform.version.contains("arm64");
 
@@ -461,7 +461,7 @@ class PackageCommand extends Command {
       }
 
       var pythonArchiveFilename =
-          "cpython-3.11.6+20231002-$arch-install_only.tar.gz";
+          "cpython-3.12.6+20240909-$arch-install_only.tar.gz";
 
       var pythonArchivePath =
           path.join(Directory.systemTemp.path, pythonArchiveFilename);

--- a/src/serious_python_android/lib/serious_python_android.dart
+++ b/src/serious_python_android/lib/serious_python_android.dart
@@ -82,6 +82,6 @@ class SeriousPythonAndroid extends SeriousPythonPlatform {
     }
 
     return runPythonProgramFFI(
-        sync ?? false, "libpython3.11.so", appPath, script ?? "");
+        sync ?? false, "libpython3.12.so", appPath, script ?? "");
   }
 }

--- a/src/serious_python_android/lib/src/gen.dart
+++ b/src/serious_python_android/lib/src/gen.dart
@@ -24677,7 +24677,7 @@ const int PY_RELEASE_LEVEL = 15;
 
 const int PY_RELEASE_SERIAL = 0;
 
-const String PY_VERSION = '3.11.6';
+const String PY_VERSION = '3.12.6';
 
 const int PY_VERSION_HEX = 51054320;
 

--- a/src/serious_python_android/python_ffigen.yaml
+++ b/src/serious_python_android/python_ffigen.yaml
@@ -14,11 +14,11 @@ globals:
     "^class (\\w+) extends ffi.Union": "final class $1 extends ffi.Union"
 headers:
   entry-points:
-    - "/Users/feodor/Downloads/python/include/python3.11/Python.h"
+    - "/Users/feodor/Downloads/python/include/python3.12/Python.h"
   include-directives:
-    - "/Users/feodor/Downloads/python/include/python3.11/*"
-    - "/Users/feodor/Downloads/python/include/python3.11/internal/*"
-    - "/Users/feodor/Downloads/python/include/python3.11/cpython/*"
+    - "/Users/feodor/Downloads/python/include/python3.12/*"
+    - "/Users/feodor/Downloads/python/include/python3.12/internal/*"
+    - "/Users/feodor/Downloads/python/include/python3.12/cpython/*"
 name: "CPython"
 llvm-path:
   - /opt/homebrew/opt/llvm

--- a/src/serious_python_darwin/darwin/Classes/SeriousPythonPlugin.swift
+++ b/src/serious_python_darwin/darwin/Classes/SeriousPythonPlugin.swift
@@ -49,7 +49,7 @@ public class SeriousPythonPlugin: NSObject, FlutterPlugin {
                 "\(appDir)/__pypackages__",
                 resourcePath,
                 "\(resourcePath)/lib/site-packages.zip",
-                "\(resourcePath)/lib/python3.11",
+                "\(resourcePath)/lib/python3.12",
                 "\(resourcePath)/python-stdlib",
                 "\(resourcePath)/python-stdlib/lib-dynload"
             ]

--- a/src/serious_python_darwin/darwin/serious_python_darwin.podspec
+++ b/src/serious_python_darwin/darwin/serious_python_darwin.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   }
   s.swift_version = '5.0'
 
-  python_framework = 'dist/xcframework/libpython3.11.xcframework'
+  python_framework = 'dist/xcframework/libpython3.12.xcframework'
   python_macos_framework = 'dist_macos/Python.xcframework'
 
   prepare_command = <<-CMD
@@ -49,16 +49,16 @@ Pod::Spec.new do |s|
       rm $PYTHON_IOS_DIST_FILE
     fi
 
-    PYTHON_MACOS_DIST_FILE=Python-3.11-macOS-support.b3.tar.gz
-    curl -LO https://github.com/beeware/Python-Apple-support/releases/download/3.11-b3/$PYTHON_MACOS_DIST_FILE
+    PYTHON_MACOS_DIST_FILE=Python-3.12-macOS-support.b4.tar.gz
+    curl -LO https://github.com/beeware/Python-Apple-support/releases/download/3.12-b4/$PYTHON_MACOS_DIST_FILE
     mkdir -p dist_macos
     tar -xzf $PYTHON_MACOS_DIST_FILE -C dist_macos
     rm $PYTHON_MACOS_DIST_FILE
 
     ROOT=`pwd`
-    cp -R pod_templates/libpython3.11.xcframework dist/xcframework
-    cp -R dist/root/python3/include/python3.11/* #{python_framework}/ios-arm64/Headers
-    cp -R dist/root/python3/include/python3.11/* #{python_framework}/ios-x86_64-simulator/Headers
+    cp -R pod_templates/libpython3.12.xcframework dist/xcframework
+    cp -R dist/root/python3/include/python3.12/* #{python_framework}/ios-arm64/Headers
+    cp -R dist/root/python3/include/python3.12/* #{python_framework}/ios-x86_64-simulator/Headers
     cp #{python_framework}/ios-arm64/Headers/module.modulemap #{python_macos_framework}/macos-arm64_x86_64/Headers
 
     # compile dist_macos/python-stdlib
@@ -81,17 +81,17 @@ Pod::Spec.new do |s|
     rm -rf python311_temp
 
     # fix import subprocess, asyncio
-    cp -R pod_templates/site-packages/* dist/root/python3/lib/python3.11/site-packages
+    cp -R pod_templates/site-packages/* dist/root/python3/lib/python3.12/site-packages
 
     # zip site-packages
-    cd dist/root/python3/lib/python3.11/site-packages
+    cd dist/root/python3/lib/python3.12/site-packages
     $ROOT/dist/hostpython3/bin/python -m compileall -b .
     find . \\( -name '*.so' -or -name '*.py' -or -name '*.typed' \\) -type f -delete
     zip -r $ROOT/dist/root/python3/lib/site-packages.zip .
     cd -
   
     # remove junk
-    rm -rf dist/root/python3/lib/python3.11
+    rm -rf dist/root/python3/lib/python3.12
 CMD
 
   puts `#{prepare_command}`

--- a/src/serious_python_linux/linux/CMakeLists.txt
+++ b/src/serious_python_linux/linux/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.10)
 # Project-level configuration.
 set(PROJECT_NAME "serious_python_linux")
 set(GITHUB_RELEASE_DATE "20231002")
-set(PYTHON_VERSION "3.11.6")
+set(PYTHON_VERSION "3.12.6")
 set(PYTHON_ARCH ${CMAKE_HOST_SYSTEM_PROCESSOR})
 project(${PROJECT_NAME} LANGUAGES CXX)
 
@@ -30,7 +30,7 @@ add_custom_command(TARGET OPTIMIZE_PYTHON_DIST PRE_BUILD
   COMMAND "${PYTHON_PACKAGE}/bin/python3" -m compileall -b .
   COMMAND rm -rf `find . -type d -name __pycache__`
   COMMAND find . -name \"*.py\" -type f -delete
-  WORKING_DIRECTORY "${PYTHON_PACKAGE}/lib/python3.11"
+  WORKING_DIRECTORY "${PYTHON_PACKAGE}/lib/python3.12"
 )
 
 # Any new source files that you add to the plugin should be added here.
@@ -62,7 +62,7 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 include_directories(
-  "${PYTHON_PACKAGE}/include/python3.11"
+  "${PYTHON_PACKAGE}/include/python3.12"
 )
 
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
@@ -76,9 +76,9 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE
 # external build triggered from this build file.
 set(serious_python_linux_bundled_libraries
   "${PYTHON_PACKAGE}/lib/libpython3.so"
-  "${PYTHON_PACKAGE}/lib/libpython3.11.so.1.0"
+  "${PYTHON_PACKAGE}/lib/libpython3.12.so.1.0"
   PARENT_SCOPE
 )
 
-install(DIRECTORY "${PYTHON_PACKAGE}/lib/python3.11"
+install(DIRECTORY "${PYTHON_PACKAGE}/lib/python3.12"
   DESTINATION "${CMAKE_BINARY_DIR}/bundle")

--- a/src/serious_python_linux/linux/serious_python_linux_plugin.cc
+++ b/src/serious_python_linux/linux/serious_python_linux_plugin.cc
@@ -101,8 +101,8 @@ static void serious_python_linux_plugin_handle_method_call(
     // system module paths
     module_paths_str_array[i++] = g_strdup_printf("%s", app_dir);
     module_paths_str_array[i++] = g_strdup_printf("%s/__pypackages__", app_dir);
-    module_paths_str_array[i++] = g_strdup_printf("%s/python3.11", exe_dir);
-    module_paths_str_array[i++] = g_strdup_printf("%s/python3.11/site-packages", exe_dir);
+    module_paths_str_array[i++] = g_strdup_printf("%s/python3.12", exe_dir);
+    module_paths_str_array[i++] = g_strdup_printf("%s/python3.12/site-packages", exe_dir);
     module_paths_str_array[i++] = NULL;
 
     gchar *module_paths_str = g_strjoinv(":", module_paths_str_array); // join with comma and space as separators

--- a/src/serious_python_platform_interface/python_ffigen.yaml
+++ b/src/serious_python_platform_interface/python_ffigen.yaml
@@ -14,11 +14,11 @@ globals:
     "^class (\\w+) extends ffi.Union": "final class $1 extends ffi.Union"
 headers:
   entry-points:
-    - "/Users/feodor/Downloads/python/include/python3.11/Python.h"
+    - "/Users/feodor/Downloads/python/include/python3.12/Python.h"
   include-directives:
-    - "/Users/feodor/Downloads/python/include/python3.11/*"
-    - "/Users/feodor/Downloads/python/include/python3.11/internal/*"
-    - "/Users/feodor/Downloads/python/include/python3.11/cpython/*"
+    - "/Users/feodor/Downloads/python/include/python3.12/*"
+    - "/Users/feodor/Downloads/python/include/python3.12/internal/*"
+    - "/Users/feodor/Downloads/python/include/python3.12/cpython/*"
 name: "CPython"
 llvm-path:
   - /opt/homebrew/opt/llvm


### PR DESCRIPTION
This is a draft PR to start the process of building in support for Python 3.12.6. There appears to be a fair bit of work involved to make this happen in a number of different dependent repos, so this may remain WIP for a while.

- python-build-standalone supports python 3.12.6 as of release https://github.com/indygreg/python-build-standalone/releases/tag/20240909
- Beeware's Python-Apple-support supports python 3.12.6 as of release https://github.com/beeware/Python-Apple-support/releases/tag/3.12-b4
- Kivy iOS needs PR to update to 3.12.6. See [this example PR](https://github.com/kivy/kivy-ios/pull/870/files)
  - PR in progress [here: kivy-ios#941](https://github.com/kivy/kivy-ios/pull/941)
- Kivy Android needs PR to update to 3.12.6. See [this example PR](https://github.com/kivy/python-for-android/pull/2850/files)
  - PR in progress [here: python-for-android#1](https://github.com/flet-dev/python-for-android/pull/1)

Fixes https://github.com/flet-dev/serious-python/issues/110

Should fix https://github.com/flet-dev/flet/issues/4007