### PR TITLE
Update build.gradle

### DIFF
--- a/src/serious_python_android/android/build.gradle
+++ b/src/serious_python_android/android/build.gradle
@@ -54,7 +54,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
 
         ndk {
             abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86_64'


### PR DESCRIPTION
Solvig this issue:

FAILURE: Build failed with an exception.

* What went wrong: A problem occurred configuring project ':serious_python_android'.
> com.android.builder.errors.EvalIssueException: [CXX1110] Platform version 16 is unsupported by this NDK. Please change minSdk to at least 21 to avoid undefined behavior. To suppress this error, add android.ndk.suppressMinSdkVersionError=21 to the project's gradle.properties or set android.experimentalProperties["android.ndk.suppressMinSdkVersionError"]=21 in the Gradle build file.