### PR TITLE
Disable user-site packages in pip environment

### DIFF
--- a/src/serious_python/bin/package_command.dart
+++ b/src/serious_python/bin/package_command.dart
@@ -321,6 +321,9 @@ class PackageCommand extends Command {
             pipEnv = {
               "PYTHONPATH":
                   [sitecustomizeDir.path].join(Platform.isWindows ? ";" : ":"),
+              // Prevent importing user-site packages (e.g. ~/.local/.../site-packages)
+              // which can shadow bundled pip in build Python.
+              "PYTHONNOUSERSITE": "1",
             };
 
             sitePackagesDir = arch.key.isNotEmpty


### PR DESCRIPTION
Set PYTHONNOUSERSITE=1 in pipEnv to prevent importing user-site packages (e.g. ~/.local/.../site-packages) that could shadow the bundled pip in the build Python. This change was added in src/serious_python/bin/package_command.dart alongside the existing PYTHONPATH handling.