### PR TITLE
Prepare release 1.0.0 (Pyodide → Emscripten breaking rename)

### DIFF
--- a/src/serious_python/CHANGELOG.md
+++ b/src/serious_python/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+* **Breaking change:** `--platform` argument value `Pyodide` has been renamed to `Emscripten` to match what `platform.system()` returns in the Pyodide runtime, so PEP 508 markers like `platform_system != 'Emscripten'` work consistently.
+
 ## 0.9.12
 
 * Fix web packaging to skip `site-packages` when appropriate ([#199](https://github.com/flet-dev/serious-python/pull/199)).

--- a/src/serious_python/README.md
+++ b/src/serious_python/README.md
@@ -85,7 +85,7 @@ To package Python files for the specific platform:
 dart run serious_python:main package app/src -p {platform}
 ```
 
-where `{platform}` can be one of the following: `Android`, `iOS`, `macOS`, `Windows`, `Linux` or `Pyodide`.
+where `{platform}` can be one of the following: `Android`, `iOS`, `macOS`, `Windows`, `Linux` or `Emscripten`.
 
 By default, the command creates `app/app.zip` asset, but you can change its path/name with `--asset` argument:
 

--- a/src/serious_python/bin/package_command.dart
+++ b/src/serious_python/bin/package_command.dart
@@ -45,7 +45,7 @@ const platforms = {
     "x86_64": {"tag": "android-24-x86_64", "mac_ver": ""},
     "x86": {"tag": "android-24-x86", "mac_ver": ""}
   },
-  "Pyodide": {
+  "Emscripten": {
     "": {"tag": "pyodide-2024.0-wasm32", "mac_ver": ""}
   },
   "Darwin": {
@@ -96,7 +96,7 @@ class PackageCommand extends Command {
   PackageCommand() {
     argParser.addOption('platform',
         abbr: "p",
-        allowed: ["iOS", "Android", "Pyodide", "Windows", "Linux", "Darwin"],
+        allowed: ["iOS", "Android", "Emscripten", "Windows", "Linux", "Darwin"],
         mandatory: true,
         help: "Install dependencies for specific platform, e.g. 'Android'.");
     argParser.addMultiOption('arch',
@@ -195,13 +195,13 @@ class PackageCommand extends Command {
       }
 
       bool isMobile = (platform == "iOS" || platform == "Android");
-      bool isWeb = platform == "Pyodide";
+      bool isWeb = platform == "Emscripten";
 
       var junkFiles = isMobile ? junkFilesMobile : junkFilesDesktop;
 
       // Extra indexs
       List<String> extraPyPiIndexes = [mobilePyPiUrl];
-      if (platform == "Pyodide") {
+      if (platform == "Emscripten") {
         pyodidePyPiServer = await startSimpleServer();
         extraPyPiIndexes.add(
             "http://${pyodidePyPiServer.address.host}:${pyodidePyPiServer.port}/simple");
@@ -430,7 +430,7 @@ class PackageCommand extends Command {
       }
 
       // copy site packages to temp dir for web platform
-      if (platform == "Pyodide" && requirements.isNotEmpty) {
+      if (platform == "Emscripten" && requirements.isNotEmpty) {
         final sitePackagesSrcDir = Directory(sitePackagesRoot);
         if (await sitePackagesSrcDir.exists()) {
           stdout.writeln("Copying site packages to app archive");

--- a/src/serious_python/example/flask_example/pubspec.lock
+++ b/src/serious_python/example/flask_example/pubspec.lock
@@ -175,10 +175,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -289,42 +289,42 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.9.12"
+    version: "1.0.0"
   serious_python_android:
     dependency: transitive
     description:
       path: "../../../serious_python_android"
       relative: true
     source: path
-    version: "0.9.12"
+    version: "1.0.0"
   serious_python_darwin:
     dependency: transitive
     description:
       path: "../../../serious_python_darwin"
       relative: true
     source: path
-    version: "0.9.12"
+    version: "1.0.0"
   serious_python_linux:
     dependency: transitive
     description:
       path: "../../../serious_python_linux"
       relative: true
     source: path
-    version: "0.9.12"
+    version: "1.0.0"
   serious_python_platform_interface:
     dependency: transitive
     description:
       path: "../../../serious_python_platform_interface"
       relative: true
     source: path
-    version: "0.9.12"
+    version: "1.0.0"
   serious_python_windows:
     dependency: transitive
     description:
       path: "../../../serious_python_windows"
       relative: true
     source: path
-    version: "0.9.12"
+    version: "1.0.0"
   shelf:
     dependency: transitive
     description:
@@ -382,10 +382,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   toml:
     dependency: transitive
     description:

--- a/src/serious_python/example/flet_example/README.md
+++ b/src/serious_python/example/flet_example/README.md
@@ -37,7 +37,7 @@ dart run serious_python:main package app/src -p Linux --requirements -r,app/src/
 For web:
 
 ```
-dart run serious_python:main package app/src -p Pyodide --requirements -r,app/src/requirements.txt
+dart run serious_python:main package app/src -p Emscripten --requirements -r,app/src/requirements.txt
 ```
 
 Important: to make `serious_python` work in your own Android app:

--- a/src/serious_python/example/flet_example/pubspec.lock
+++ b/src/serious_python/example/flet_example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -280,10 +280,10 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   js:
     dependency: transitive
     description:
@@ -304,26 +304,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -352,26 +352,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   package_info_plus:
     dependency: "direct main"
     description:
@@ -562,42 +562,42 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.9.12"
+    version: "1.0.0"
   serious_python_android:
     dependency: transitive
     description:
       path: "../../../serious_python_android"
       relative: true
     source: path
-    version: "0.9.12"
+    version: "1.0.0"
   serious_python_darwin:
     dependency: transitive
     description:
       path: "../../../serious_python_darwin"
       relative: true
     source: path
-    version: "0.9.12"
+    version: "1.0.0"
   serious_python_linux:
     dependency: transitive
     description:
       path: "../../../serious_python_linux"
       relative: true
     source: path
-    version: "0.9.12"
+    version: "1.0.0"
   serious_python_platform_interface:
     dependency: transitive
     description:
       path: "../../../serious_python_platform_interface"
       relative: true
     source: path
-    version: "0.9.12"
+    version: "1.0.0"
   serious_python_windows:
     dependency: transitive
     description:
       path: "../../../serious_python_windows"
       relative: true
     source: path
-    version: "0.9.12"
+    version: "1.0.0"
   shared_preferences:
     dependency: transitive
     description:
@@ -719,10 +719,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.10"
   toml:
     dependency: transitive
     description:
@@ -839,10 +839,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -924,5 +924,5 @@ packages:
     source: hosted
     version: "6.5.0"
 sdks:
-  dart: ">=3.7.0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.22.0"

--- a/src/serious_python/example/run_example/README.md
+++ b/src/serious_python/example/run_example/README.md
@@ -40,7 +40,7 @@ dart run serious_python:main package app/src -p Linux -r -r -r app/src/requireme
 For Pyodide:
 
 ```
-dart run serious_python:main package app/src -p Pyodide -r -r -r app/src/requirements.txt
+dart run serious_python:main package app/src -p Emscripten -r -r -r app/src/requirements.txt
 ```
 
 For Android:

--- a/src/serious_python/example/run_example/pubspec.lock
+++ b/src/serious_python/example/run_example/pubspec.lock
@@ -190,10 +190,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -312,42 +312,42 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.9.12"
+    version: "1.0.0"
   serious_python_android:
     dependency: transitive
     description:
       path: "../../../serious_python_android"
       relative: true
     source: path
-    version: "0.9.12"
+    version: "1.0.0"
   serious_python_darwin:
     dependency: transitive
     description:
       path: "../../../serious_python_darwin"
       relative: true
     source: path
-    version: "0.9.12"
+    version: "1.0.0"
   serious_python_linux:
     dependency: transitive
     description:
       path: "../../../serious_python_linux"
       relative: true
     source: path
-    version: "0.9.12"
+    version: "1.0.0"
   serious_python_platform_interface:
     dependency: transitive
     description:
       path: "../../../serious_python_platform_interface"
       relative: true
     source: path
-    version: "0.9.12"
+    version: "1.0.0"
   serious_python_windows:
     dependency: transitive
     description:
       path: "../../../serious_python_windows"
       relative: true
     source: path
-    version: "0.9.12"
+    version: "1.0.0"
   shelf:
     dependency: transitive
     description:
@@ -413,10 +413,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   toml:
     dependency: transitive
     description:

--- a/src/serious_python/pubspec.yaml
+++ b/src/serious_python/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python
 description: A cross-platform plugin for adding embedded Python runtime to your Flutter apps.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 0.9.12
+version: 1.0.0
 
 platforms:
   ios:

--- a/src/serious_python_android/CHANGELOG.md
+++ b/src/serious_python_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+* **Breaking change:** `--platform` argument value `Pyodide` has been renamed to `Emscripten` to match what `platform.system()` returns in the Pyodide runtime, so PEP 508 markers like `platform_system != 'Emscripten'` work consistently.
+
 ## 0.9.12
 
 * Fix web packaging to skip `site-packages` when appropriate ([#199](https://github.com/flet-dev/serious-python/pull/199)).

--- a/src/serious_python_android/android/build.gradle
+++ b/src/serious_python_android/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.flet.serious_python_android'
-version '0.9.12'
+version '1.0.0'
     
 def python_version = '3.12'
 

--- a/src/serious_python_android/pubspec.yaml
+++ b/src/serious_python_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_android
 description: Android implementation of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 0.9.12
+version: 1.0.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/src/serious_python_darwin/CHANGELOG.md
+++ b/src/serious_python_darwin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+* **Breaking change:** `--platform` argument value `Pyodide` has been renamed to `Emscripten` to match what `platform.system()` returns in the Pyodide runtime, so PEP 508 markers like `platform_system != 'Emscripten'` work consistently.
+
 ## 0.9.12
 
 * Fix web packaging to skip `site-packages` when appropriate ([#199](https://github.com/flet-dev/serious-python/pull/199)).

--- a/src/serious_python_darwin/darwin/serious_python_darwin.podspec
+++ b/src/serious_python_darwin/darwin/serious_python_darwin.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'serious_python_darwin'
-  s.version          = '0.9.12'
+  s.version          = '1.0.0'
   s.summary          = 'A cross-platform plugin for adding embedded Python runtime to your Flutter apps.'
   s.description      = <<-DESC
   A cross-platform plugin for adding embedded Python runtime to your Flutter apps.

--- a/src/serious_python_darwin/pubspec.yaml
+++ b/src/serious_python_darwin/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_darwin
 description: iOS and macOS implementations of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 0.9.12
+version: 1.0.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/src/serious_python_linux/CHANGELOG.md
+++ b/src/serious_python_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+* **Breaking change:** `--platform` argument value `Pyodide` has been renamed to `Emscripten` to match what `platform.system()` returns in the Pyodide runtime, so PEP 508 markers like `platform_system != 'Emscripten'` work consistently.
+
 ## 0.9.12
 
 * Fix web packaging to skip `site-packages` when appropriate ([#199](https://github.com/flet-dev/serious-python/pull/199)).

--- a/src/serious_python_linux/pubspec.yaml
+++ b/src/serious_python_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_linux
 description: Linux implementations of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 0.9.12
+version: 1.0.0
 
 environment:
   sdk: '>=3.1.3 <4.0.0'

--- a/src/serious_python_platform_interface/CHANGELOG.md
+++ b/src/serious_python_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+* **Breaking change:** `--platform` argument value `Pyodide` has been renamed to `Emscripten` to match what `platform.system()` returns in the Pyodide runtime, so PEP 508 markers like `platform_system != 'Emscripten'` work consistently.
+
 ## 0.9.12
 
 * Fix web packaging to skip `site-packages` when appropriate ([#199](https://github.com/flet-dev/serious-python/pull/199)).

--- a/src/serious_python_platform_interface/pubspec.yaml
+++ b/src/serious_python_platform_interface/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_platform_interface
 description: A common platform interface for the serious_python plugin.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 0.9.12
+version: 1.0.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/src/serious_python_windows/CHANGELOG.md
+++ b/src/serious_python_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+* **Breaking change:** `--platform` argument value `Pyodide` has been renamed to `Emscripten` to match what `platform.system()` returns in the Pyodide runtime, so PEP 508 markers like `platform_system != 'Emscripten'` work consistently.
+
 ## 0.9.12
 
 * Fix web packaging to skip `site-packages` when appropriate ([#199](https://github.com/flet-dev/serious-python/pull/199)).

--- a/src/serious_python_windows/pubspec.yaml
+++ b/src/serious_python_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_windows
 description: Windows implementations of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 0.9.12
+version: 1.0.0
 
 environment:
   sdk: '>=3.1.3 <4.0.0'


### PR DESCRIPTION
## Summary
- Rename the `--platform` argument value `Pyodide` to `Emscripten` so it matches what `platform.system()` returns inside the Pyodide runtime, keeping PEP 508 markers like `platform_system != 'Emscripten'` consistent across build-time and in-browser micropip paths.
- Bump all packages (serious_python and the 5 platform packages, podspec, Android `build.gradle`) to **1.0.0** and refresh example app `pubspec.lock` files.
- Add a 1.0.0 entry to all six `CHANGELOG.md` files marking the rename as a **breaking change**.

## Test plan
- [ ] CI green on the branch
- [ ] Verify `package` command with `--platform Emscripten` produces the expected web build
- [ ] Confirm PEP 508 markers `platform_system != 'Emscripten'` resolve correctly during pip resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)