### PR TITLE
Set PIP_REQUIRE_VIRTUALENV=false to make package command work in restricted environments

### DIFF
--- a/src/serious_python/bin/package_command.dart
+++ b/src/serious_python/bin/package_command.dart
@@ -321,6 +321,9 @@ class PackageCommand extends Command {
               // Prevent importing user-site packages (e.g. ~/.local/.../site-packages)
               // which can shadow bundled pip in build Python.
               "PYTHONNOUSERSITE": "1",
+              // Override any user-set `require-virtualenv = true` (pip.conf or
+              // PIP_REQUIRE_VIRTUALENV) which otherwise aborts the install.
+              "PIP_REQUIRE_VIRTUALENV": "false",
             };
 
             sitePackagesDir = arch.key.isNotEmpty


### PR DESCRIPTION
## Summary
- Adds `PIP_REQUIRE_VIRTUALENV=false` to the environment passed to the `pip install` invocation in the `package` command.
- This overrides any user-set `require-virtualenv = true` (from `~/.pip/pip.conf` or an inherited `PIP_REQUIRE_VIRTUALENV` env var), which otherwise aborts packaging with `ERROR: Could not find an activated virtualenv (required)`.

Fixes #202. The workaround (`PIP_REQUIRE_VIRTUALENV=false uv run flet build web`) was confirmed in flet-dev/flet#6497; this applies it automatically.

## Test plan
- [ ] With `require-virtualenv = true` in `~/.pip/pip.conf`, run `flet build web` (or the `package` command) and confirm packaging succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)