### PR TITLE
Prepare release 1.0.1

### DIFF
--- a/src/serious_python/CHANGELOG.md
+++ b/src/serious_python/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Set `PIP_REQUIRE_VIRTUALENV=false` for `pip install` so the package command works when `require-virtualenv = true` is set in pip config ([#202](https://github.com/flet-dev/serious-python/issues/202)).
+
 ## 1.0.0
 
 * **Breaking change:** `--platform` argument value `Pyodide` has been renamed to `Emscripten` to match what `platform.system()` returns in the Pyodide runtime, so PEP 508 markers like `platform_system != 'Emscripten'` work consistently.

--- a/src/serious_python/bin/package_command.dart
+++ b/src/serious_python/bin/package_command.dart
@@ -321,6 +321,9 @@ class PackageCommand extends Command {
               // Prevent importing user-site packages (e.g. ~/.local/.../site-packages)
               // which can shadow bundled pip in build Python.
               "PYTHONNOUSERSITE": "1",
+              // Override any user-set `require-virtualenv = true` (pip.conf or
+              // PIP_REQUIRE_VIRTUALENV) which otherwise aborts the install.
+              "PIP_REQUIRE_VIRTUALENV": "false",
             };
 
             sitePackagesDir = arch.key.isNotEmpty

--- a/src/serious_python/example/flask_example/pubspec.lock
+++ b/src/serious_python/example/flask_example/pubspec.lock
@@ -289,42 +289,42 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   serious_python_android:
     dependency: transitive
     description:
       path: "../../../serious_python_android"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   serious_python_darwin:
     dependency: transitive
     description:
       path: "../../../serious_python_darwin"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   serious_python_linux:
     dependency: transitive
     description:
       path: "../../../serious_python_linux"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   serious_python_platform_interface:
     dependency: transitive
     description:
       path: "../../../serious_python_platform_interface"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   serious_python_windows:
     dependency: transitive
     description:
       path: "../../../serious_python_windows"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   shelf:
     dependency: transitive
     description:

--- a/src/serious_python/example/flet_example/pubspec.lock
+++ b/src/serious_python/example/flet_example/pubspec.lock
@@ -562,42 +562,42 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   serious_python_android:
     dependency: transitive
     description:
       path: "../../../serious_python_android"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   serious_python_darwin:
     dependency: transitive
     description:
       path: "../../../serious_python_darwin"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   serious_python_linux:
     dependency: transitive
     description:
       path: "../../../serious_python_linux"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   serious_python_platform_interface:
     dependency: transitive
     description:
       path: "../../../serious_python_platform_interface"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   serious_python_windows:
     dependency: transitive
     description:
       path: "../../../serious_python_windows"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   shared_preferences:
     dependency: transitive
     description:

--- a/src/serious_python/example/run_example/pubspec.lock
+++ b/src/serious_python/example/run_example/pubspec.lock
@@ -312,42 +312,42 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   serious_python_android:
     dependency: transitive
     description:
       path: "../../../serious_python_android"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   serious_python_darwin:
     dependency: transitive
     description:
       path: "../../../serious_python_darwin"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   serious_python_linux:
     dependency: transitive
     description:
       path: "../../../serious_python_linux"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   serious_python_platform_interface:
     dependency: transitive
     description:
       path: "../../../serious_python_platform_interface"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   serious_python_windows:
     dependency: transitive
     description:
       path: "../../../serious_python_windows"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   shelf:
     dependency: transitive
     description:

--- a/src/serious_python/pubspec.yaml
+++ b/src/serious_python/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python
 description: A cross-platform plugin for adding embedded Python runtime to your Flutter apps.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 1.0.0
+version: 1.0.1
 
 platforms:
   ios:

--- a/src/serious_python_android/CHANGELOG.md
+++ b/src/serious_python_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Set `PIP_REQUIRE_VIRTUALENV=false` for `pip install` so the package command works when `require-virtualenv = true` is set in pip config ([#202](https://github.com/flet-dev/serious-python/issues/202)).
+
 ## 1.0.0
 
 * **Breaking change:** `--platform` argument value `Pyodide` has been renamed to `Emscripten` to match what `platform.system()` returns in the Pyodide runtime, so PEP 508 markers like `platform_system != 'Emscripten'` work consistently.

--- a/src/serious_python_android/android/build.gradle
+++ b/src/serious_python_android/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.flet.serious_python_android'
-version '1.0.0'
+version '1.0.1'
     
 def python_version = '3.12'
 

--- a/src/serious_python_android/pubspec.yaml
+++ b/src/serious_python_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_android
 description: Android implementation of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 1.0.0
+version: 1.0.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/src/serious_python_darwin/CHANGELOG.md
+++ b/src/serious_python_darwin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Set `PIP_REQUIRE_VIRTUALENV=false` for `pip install` so the package command works when `require-virtualenv = true` is set in pip config ([#202](https://github.com/flet-dev/serious-python/issues/202)).
+
 ## 1.0.0
 
 * **Breaking change:** `--platform` argument value `Pyodide` has been renamed to `Emscripten` to match what `platform.system()` returns in the Pyodide runtime, so PEP 508 markers like `platform_system != 'Emscripten'` work consistently.

--- a/src/serious_python_darwin/darwin/serious_python_darwin.podspec
+++ b/src/serious_python_darwin/darwin/serious_python_darwin.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'serious_python_darwin'
-  s.version          = '1.0.0'
+  s.version          = '1.0.1'
   s.summary          = 'A cross-platform plugin for adding embedded Python runtime to your Flutter apps.'
   s.description      = <<-DESC
   A cross-platform plugin for adding embedded Python runtime to your Flutter apps.

--- a/src/serious_python_darwin/pubspec.yaml
+++ b/src/serious_python_darwin/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_darwin
 description: iOS and macOS implementations of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 1.0.0
+version: 1.0.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/src/serious_python_linux/CHANGELOG.md
+++ b/src/serious_python_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Set `PIP_REQUIRE_VIRTUALENV=false` for `pip install` so the package command works when `require-virtualenv = true` is set in pip config ([#202](https://github.com/flet-dev/serious-python/issues/202)).
+
 ## 1.0.0
 
 * **Breaking change:** `--platform` argument value `Pyodide` has been renamed to `Emscripten` to match what `platform.system()` returns in the Pyodide runtime, so PEP 508 markers like `platform_system != 'Emscripten'` work consistently.

--- a/src/serious_python_linux/pubspec.yaml
+++ b/src/serious_python_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_linux
 description: Linux implementations of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 1.0.0
+version: 1.0.1
 
 environment:
   sdk: '>=3.1.3 <4.0.0'

--- a/src/serious_python_platform_interface/CHANGELOG.md
+++ b/src/serious_python_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Set `PIP_REQUIRE_VIRTUALENV=false` for `pip install` so the package command works when `require-virtualenv = true` is set in pip config ([#202](https://github.com/flet-dev/serious-python/issues/202)).
+
 ## 1.0.0
 
 * **Breaking change:** `--platform` argument value `Pyodide` has been renamed to `Emscripten` to match what `platform.system()` returns in the Pyodide runtime, so PEP 508 markers like `platform_system != 'Emscripten'` work consistently.

--- a/src/serious_python_platform_interface/pubspec.yaml
+++ b/src/serious_python_platform_interface/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_platform_interface
 description: A common platform interface for the serious_python plugin.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 1.0.0
+version: 1.0.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/src/serious_python_windows/CHANGELOG.md
+++ b/src/serious_python_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Set `PIP_REQUIRE_VIRTUALENV=false` for `pip install` so the package command works when `require-virtualenv = true` is set in pip config ([#202](https://github.com/flet-dev/serious-python/issues/202)).
+
 ## 1.0.0
 
 * **Breaking change:** `--platform` argument value `Pyodide` has been renamed to `Emscripten` to match what `platform.system()` returns in the Pyodide runtime, so PEP 508 markers like `platform_system != 'Emscripten'` work consistently.

--- a/src/serious_python_windows/pubspec.yaml
+++ b/src/serious_python_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_windows
 description: Windows implementations of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 1.0.0
+version: 1.0.1
 
 environment:
   sdk: '>=3.1.3 <4.0.0'


### PR DESCRIPTION
## Summary
- Bumps all package versions from 1.0.0 to 1.0.1 (pubspec.yaml ×6, podspec, Android build.gradle).
- Adds a 1.0.1 CHANGELOG entry to all six packages for the `PIP_REQUIRE_VIRTUALENV` packaging fix.
- Refreshes the three example apps' `pubspec.lock` files.

Stacked on top of #204 (the #202 fix) so the release ships with the fix. Will auto-retarget to `main` once #204 merges.

## Test plan
- [ ] `flutter pub get` succeeds in all three example apps (done locally).
- [ ] Version strings are consistent across pubspec.yaml, podspec, and build.gradle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)