### PR TITLE
serious_python_darwin (SPM): force-load only dart_bridge on macOS (fix duplicate-symbol link errors)

### DIFF
--- a/src/serious_python_darwin/darwin/serious_python_darwin/Package.swift
+++ b/src/serious_python_darwin/darwin/serious_python_darwin/Package.swift
@@ -44,10 +44,36 @@ func staged(_ rel: String) -> Bool {
 var binaryTargets: [Target] = []
 var deps: [Target.Dependency] = [.product(name: "FlutterFramework", package: "FlutterFramework")]
 
-// dart_bridge: static archive, link-only (forced in via -all_load). Multi-platform.
+// dart_bridge: static archive, link-only. Its FFI exports are resolved at runtime
+// via dlsym (Dart's `DynamicLibrary.process()` and Python's `import dart_bridge`),
+// so the whole archive must be retained against the linker's -dead_strip. We
+// force-load JUST this archive rather than using a global -all_load: SwiftPM
+// applies a target's linkerSettings to the FINAL app executable link, so a global
+// -all_load there would force-load EVERY static archive on the link line —
+// including plugins that statically bundle the same third-party code (e.g.
+// flet-video/media_kit and flet-rive both embed miniaudio), which then collide
+// with thousands of duplicate symbols. -force_load on dart_bridge alone mirrors
+// what the CocoaPods podspec did via `pod_target_xcconfig` (scoped to this pod's
+// own inputs — only dart_bridge among them is a static archive). On macOS the
+// xcframework has a single universal slice with a stable path, so we resolve it
+// here. On iOS, plugin pods link as dynamic frameworks (no static-archive
+// collision) and device/simulator use different slice paths, so the
+// slice-agnostic -all_load is kept there (see linkerSettings below).
+var macosDartBridgeForceLoad: [String] = []
 if staged("dart_bridge.xcframework") {
     binaryTargets.append(.binaryTarget(name: "dart_bridge", path: "dart_bridge.xcframework"))
     deps.append("dart_bridge")
+    let xc = pkgDir.appendingPathComponent("dart_bridge.xcframework")
+    if let slices = try? FileManager.default.contentsOfDirectory(
+        at: xc, includingPropertiesForKeys: nil) {
+        for slice in slices.sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
+            where slice.lastPathComponent.hasPrefix("macos") {
+            let lib = slice.appendingPathComponent("libdart_bridge.a")
+            if FileManager.default.fileExists(atPath: lib.path) {
+                macosDartBridgeForceLoad = ["-force_load", lib.path]
+            }
+        }
+    }
 }
 // Python.framework: dynamic -> embedded + auto-signed. iOS and macOS ship separate
 // xcframeworks, so each is platform-conditional.
@@ -93,8 +119,15 @@ let package = Package(
                 .copy("Resources/app"),
             ],
             linkerSettings: [
-                // Reproduces the podspec OTHER_LDFLAGS = '-ObjC -all_load -lc++'.
-                .unsafeFlags(["-ObjC", "-all_load"]),
+                .unsafeFlags(["-ObjC"]),
+                // iOS: slice-agnostic -all_load. Plugin pods link as dynamic
+                // frameworks, so dart_bridge is the only static archive in scope —
+                // nothing else to double-load. (device/simulator slice paths differ,
+                // so a single -force_load path isn't possible here.)
+                .unsafeFlags(["-all_load"], .when(platforms: [.iOS])),
+                // macOS: force-load ONLY dart_bridge (resolved above), never a global
+                // -all_load — see the note where macosDartBridgeForceLoad is built.
+                .unsafeFlags(macosDartBridgeForceLoad, .when(platforms: [.macOS])),
                 .linkedLibrary("c++"),
             ]
         ),


### PR DESCRIPTION
## Problem

In flet build CI, macOS SPM builds failed with ~1159 `ld: duplicate symbol` errors (miniaudio `ma_*` symbols), defined in both **media_kit** (flet-video: `miniaudio.o`/`miniaudio1.o`) and **flet-rive** (`libRiveNative.a`) — both statically bundle miniaudio.

## Root cause

The SPM port reproduced the podspec's `OTHER_LDFLAGS = -ObjC -all_load -lc++` as a `Package.swift` `linkerSettings` entry. But SwiftPM applies a target's `linkerSettings` to the **final app executable** link, so `-all_load` became **global** — force-loading *every* static archive on the link line, including both copies of miniaudio → duplicate symbols.

CocoaPods never hit this because the podspec sets the flag via **`pod_target_xcconfig`**, scoping `-all_load` to serious_python_darwin's own target — whose only static input is `dart_bridge` (Python.framework is dynamic). It never touched media_kit/Rive.

iOS was unaffected: its plugin pods link as dynamic frameworks, so `dart_bridge` is the only static archive in scope.

## Fix

Mirror the podspec's scoping under SPM:
- **macOS:** `-force_load` **only** dart_bridge's archive (single universal slice; path resolved from the staged `dart_bridge.xcframework` at manifest-eval time). No global `-all_load`.
- **iOS:** keep the slice-agnostic `-all_load` (device/simulator slices use different paths, and there's no static-archive collision there).
- `-ObjC` and `-lc++` unchanged on both.

dart_bridge's 16 FFI exports are resolved at runtime via `dlsym` (`DynamicLibrary.process()` / `import dart_bridge`), so the whole archive must stay retained — `-force_load` keeps that guarantee while touching nothing else.

`swift package dump-package` confirms the per-platform flags resolve correctly.

## Reaches flet build via
serious_python is a git dep at `ref: main` in flet's build template, so this lands on main to flow into flet CI.

## Test plan
- [x] `swift package dump-package` parses; flags correct per platform
- [ ] flet build CI: macOS + iOS (ipa/simulator) across 3.12/3.13/3.14 — iOS already green on the prior run; this fixes the remaining macOS link failure