### PR TITLE
fix(android): bundle every ABI's _sysconfigdata into the ABI-common stdlib.zip

### DIFF
--- a/src/serious_python_android/CHANGELOG.md
+++ b/src/serious_python_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.1
+
+* Fix the embedded interpreter crashing on startup on a **non-primary ABI** (e.g. an x86_64 emulator when `arm64-v8a` is the primary ABI) with `ModuleNotFoundError: No module named '_sysconfigdata__android_<arch>-linux-android'`. The ABI-common `stdlib.zip` was built from the primary ABI only, dropping every other ABI's arch-specific `_sysconfigdata__android_<arch>` module — which CPython imports at startup via `sysconfig` (pulled in by `ctypes`). The primary `splitStdlib` task now also harvests each other ABI's `_sysconfigdata__android_<arch>` into `stdlib.zip` (only that arch-specific module, so the generic ABI-identical `_sysconfigdata__linux_` shipped by some versions like 3.12 isn't duplicated).
+
 ## 4.1.0
 
 * Run the `extractAsset` / `unzipAsset` / `loadLibrary` method-channel handlers on a background `Executor` (posting the `Result` back on the main looper) instead of inline on the platform main thread. The first-launch asset unpack and the pyjnius native-library load no longer block Android's `Choreographer`, so Flutter's vsync isn't starved and on-screen animations (e.g. a boot/splash spinner) stay smooth while the app starts.

--- a/src/serious_python_android/android/build.gradle.kts
+++ b/src/serious_python_android/android/build.gradle.kts
@@ -302,14 +302,18 @@ for (abi in abis) {
                     }
                 }
             }
-            // `_sysconfigdata__<arch>` is the one pure-stdlib module whose name and
-            // contents are ARCH-SPECIFIC: each ABI ships its own (e.g.
-            // `_sysconfigdata__android_x86_64-linux-android`) and CPython imports
-            // the one matching the running device at startup (sysconfig, pulled in
-            // by ctypes). Since stdlib.zip is ABI-common and built from the primary
-            // ABI only, harvest every other ABI's sysconfigdata into it — otherwise
-            // a non-primary ABI (e.g. an x86_64 emulator when arm64-v8a is primary)
+            // `_sysconfigdata__android_<arch>` is ARCH-SPECIFIC: each ABI ships its
+            // own (e.g. `_sysconfigdata__android_x86_64-linux-android`) and CPython
+            // imports the one matching the running device at startup (sysconfig,
+            // pulled in by ctypes). Since stdlib.zip is ABI-common and built from the
+            // primary ABI only, harvest every other ABI's into it — otherwise a
+            // non-primary ABI (e.g. an x86_64 emulator when arm64-v8a is primary)
             // crashes with `ModuleNotFoundError: _sysconfigdata__android_...`.
+            //
+            // Match ONLY the `_sysconfigdata__android_<arch>` files (unique per ABI),
+            // not the generic, ABI-identical `_sysconfigdata__linux_` that some
+            // versions (e.g. 3.12) also ship — the primary already added that via the
+            // stdlib loop above, so harvesting it again would be a duplicate zip entry.
             if (isPrimary) {
                 abis.filter { it != abi }.forEach { otherAbi ->
                     val otherBundle = File(file("src/main/jniLibs/$otherAbi"), "libpythonbundle.so")
@@ -318,7 +322,9 @@ for (abi in abis) {
                             val oen = ozf.entries()
                             while (oen.hasMoreElements()) {
                                 val oe = oen.nextElement()
-                                if (!oe.isDirectory && oe.name.startsWith("stdlib/_sysconfigdata")) {
+                                if (!oe.isDirectory &&
+                                    oe.name.startsWith("stdlib/_sysconfigdata__android")
+                                ) {
                                     zip?.add(
                                         oe.name.removePrefix("stdlib/"),
                                         ozf.getInputStream(oe).readBytes(),

--- a/src/serious_python_android/android/build.gradle.kts
+++ b/src/serious_python_android/android/build.gradle.kts
@@ -259,6 +259,16 @@ for (abi in abis) {
     // (+ .soref markers in stdlib.zip), stdlib/* -> stdlib.zip root, then delete it.
     tasks.register("splitStdlib_$abi") {
         dependsOn("untarFile_$abi")
+        // The ABI-common stdlib.zip is built once (from the primary ABI) but must
+        // also carry every OTHER ABI's arch-specific `_sysconfigdata__<arch>` (see
+        // the harvest in doLast). Make the primary task depend on the other ABIs'
+        // untar so their bundles exist to read, and hold non-primary tasks until
+        // the primary has read them (each task deletes its own bundle at the end).
+        if (isPrimary) {
+            abis.forEach { other -> if (other != abi) dependsOn("untarFile_$other") }
+        } else {
+            mustRunAfter("splitStdlib_$primaryAbi")
+        }
         // The doLast rewrites jniLibs/<abi> (mangled libs in, bundle out); declare it as a
         // tracked output and always re-run so AGP's native-libs merge re-packages.
         outputs.dir(jniDir)
@@ -289,6 +299,33 @@ for (abi in abis) {
                         }
                         name.startsWith("stdlib/") -> zip?.add(name.removePrefix("stdlib/"), data)
                         else -> zip?.add(name, data)
+                    }
+                }
+            }
+            // `_sysconfigdata__<arch>` is the one pure-stdlib module whose name and
+            // contents are ARCH-SPECIFIC: each ABI ships its own (e.g.
+            // `_sysconfigdata__android_x86_64-linux-android`) and CPython imports
+            // the one matching the running device at startup (sysconfig, pulled in
+            // by ctypes). Since stdlib.zip is ABI-common and built from the primary
+            // ABI only, harvest every other ABI's sysconfigdata into it — otherwise
+            // a non-primary ABI (e.g. an x86_64 emulator when arm64-v8a is primary)
+            // crashes with `ModuleNotFoundError: _sysconfigdata__android_...`.
+            if (isPrimary) {
+                abis.filter { it != abi }.forEach { otherAbi ->
+                    val otherBundle = File(file("src/main/jniLibs/$otherAbi"), "libpythonbundle.so")
+                    if (otherBundle.exists()) {
+                        ZipFile(otherBundle).use { ozf ->
+                            val oen = ozf.entries()
+                            while (oen.hasMoreElements()) {
+                                val oe = oen.nextElement()
+                                if (!oe.isDirectory && oe.name.startsWith("stdlib/_sysconfigdata")) {
+                                    zip?.add(
+                                        oe.name.removePrefix("stdlib/"),
+                                        ozf.getInputStream(oe).readBytes(),
+                                    )
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Problem

The pure `stdlib.zip` is ABI-common and built once from the **primary ABI** (`abis.first()`, e.g. `arm64-v8a`). But `_sysconfigdata__<arch>` is **arch-specific**: each ABI ships its own (e.g. `_sysconfigdata__android_x86_64-linux-android`), and CPython imports the one matching the running device at startup (`sysconfig._init_posix`, pulled in by `ctypes`).

So on a **non-primary ABI** (e.g. an x86_64 emulator when arm64-v8a is primary) the embedded interpreter crashes on startup:

```
ModuleNotFoundError: No module named '_sysconfigdata__android_x86_64-linux-android'
```

This was caught by Flet's new on-device `flet test` CI running on an x86_64 Android emulator (passes on arm64 devices/emulators, where the primary ABI's sysconfigdata happens to match).

## Fix

The primary `splitStdlib` task now also harvests every **other** ABI's `stdlib/_sysconfigdata*` from its `libpythonbundle.so` into `stdlib.zip` — depending on the other ABIs' untar so their bundles exist to read, and holding non-primary tasks until the primary has read them (each task deletes its own bundle at the end).

## Validation

A patched APK build's `stdlib.zip` now contains **both** `_sysconfigdata__android_aarch64-linux-android.pyc` and `_sysconfigdata__android_x86_64-linux-android.pyc` (previously only the aarch64 one).