### PR TITLE
Bump to 4.1.1: Android startup crash fixes

### DIFF
--- a/src/serious_python/CHANGELOG.md
+++ b/src/serious_python/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.1
+
+* **Android:** fix two startup crashes — apps crashing on launch on Android 8.1 and below (API < 28) due to an unguarded `getLongVersionCode()` call, and the interpreter failing to start on a non-primary ABI (e.g. an x86_64 emulator) with `ModuleNotFoundError: No module named '_sysconfigdata__android_<arch>-linux-android'`. See `serious_python_android` 4.1.1.
+
 ## 4.1.0
 
 * **Android:** run first-launch asset unpacking and native library loading off the platform main thread so they no longer block vsync — boot-time animations (e.g. a splash / boot screen spinner) stay smooth while the app starts. Also ship consumer ProGuard rules that keep the pyjnius bootstrap classes, fixing pyjnius in release (minified) Android builds. See `serious_python_android` 4.1.0.

--- a/src/serious_python/pubspec.yaml
+++ b/src/serious_python/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python
 description: A cross-platform plugin for adding embedded Python runtime to your Flutter apps.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.1.0
+version: 4.1.1
 
 platforms:
   ios:

--- a/src/serious_python_android/android/build.gradle.kts
+++ b/src/serious_python_android/android/build.gradle.kts
@@ -21,7 +21,7 @@ buildscript {
 }
 
 group = "com.flet.serious_python_android"
-version = "4.1.0"
+version = "4.1.1"
 
 rootProject.allprojects {
     repositories {

--- a/src/serious_python_android/pubspec.yaml
+++ b/src/serious_python_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_android
 description: Android implementation of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.1.0
+version: 4.1.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/src/serious_python_darwin/CHANGELOG.md
+++ b/src/serious_python_darwin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.1
+
+* Version bump aligning with the `serious_python_*` 4.1.1 release.
+
 ## 4.1.0
 
 * Version bump aligning with the `serious_python_*` 4.1.0 release.

--- a/src/serious_python_darwin/darwin/serious_python_darwin.podspec
+++ b/src/serious_python_darwin/darwin/serious_python_darwin.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'serious_python_darwin'
-  s.version          = '4.1.0'
+  s.version          = '4.1.1'
   s.summary          = 'A cross-platform plugin for adding embedded Python runtime to your Flutter apps.'
   s.description      = <<-DESC
   A cross-platform plugin for adding embedded Python runtime to your Flutter apps.

--- a/src/serious_python_darwin/pubspec.yaml
+++ b/src/serious_python_darwin/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_darwin
 description: iOS and macOS implementations of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.1.0
+version: 4.1.1
 
 environment:
   # The Swift Package Manager build path needs Flutter 3.44 / Dart 3.11 (the

--- a/src/serious_python_linux/CHANGELOG.md
+++ b/src/serious_python_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.1
+
+* Version bump aligning with the `serious_python_*` 4.1.1 release.
+
 ## 4.1.0
 
 * Version bump aligning with the `serious_python_*` 4.1.0 release.

--- a/src/serious_python_linux/pubspec.yaml
+++ b/src/serious_python_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_linux
 description: Linux implementations of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.1.0
+version: 4.1.1
 
 environment:
   sdk: '>=3.1.3 <4.0.0'

--- a/src/serious_python_platform_interface/CHANGELOG.md
+++ b/src/serious_python_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.1
+
+* Version bump aligning with the `serious_python_*` 4.1.1 release.
+
 ## 4.1.0
 
 * Version bump aligning with the `serious_python_*` 4.1.0 release.

--- a/src/serious_python_platform_interface/pubspec.yaml
+++ b/src/serious_python_platform_interface/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_platform_interface
 description: A common platform interface for the serious_python plugin.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.1.0
+version: 4.1.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/src/serious_python_windows/CHANGELOG.md
+++ b/src/serious_python_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.1
+
+* Version bump aligning with the `serious_python_*` 4.1.1 release.
+
 ## 4.1.0
 
 * Version bump aligning with the `serious_python_*` 4.1.0 release.

--- a/src/serious_python_windows/pubspec.yaml
+++ b/src/serious_python_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_windows
 description: Windows implementations of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.1.0
+version: 4.1.1
 
 environment:
   sdk: '>=3.1.3 <4.0.0'


### PR DESCRIPTION
Prepares the **4.1.1** release — lockstep version bump across all packages plus CHANGELOG entries.

## Version bumps `4.1.0 → 4.1.1`
- All 6 `pubspec.yaml` (serious_python + android/darwin/linux/windows/platform_interface)
- `serious_python_darwin.podspec`
- android `build.gradle.kts`

## CHANGELOGs
- **serious_python_android** — already carried its 4.1.1 entry (landed with #218/#219).
- **serious_python** — new 4.1.1 entry summarizing both Android fixes.
- darwin / linux / windows / platform_interface — "Version bump aligning" entries.

## Contents (fixes since v4.1.0)
- #219 — guard `getLongVersionCode()` for API < 28 (launch crash on Android 8.1 and below)
- #218 — bundle every ABI's `_sysconfigdata` into `stdlib.zip` (non-primary-ABI startup crash)