### PR TITLE
fix(darwin): framework-ize ctypes `.dylib` libs so they load on the iOS simulator

### DIFF
--- a/src/serious_python_darwin/darwin/sync_site_packages.sh
+++ b/src/serious_python_darwin/darwin/sync_site_packages.sh
@@ -33,15 +33,25 @@ if [[ -n "$SERIOUS_PYTHON_SITE_PACKAGES" && -d "$SERIOUS_PYTHON_SITE_PACKAGES" ]
         cp -R $SERIOUS_PYTHON_SITE_PACKAGES/* $tmp_dir
 
         echo "Converting dylibs to xcframeworks..."
-        find "$tmp_dir/${archs[0]}" -name "*.$dylib_ext" | while read full_dylib; do
+        # Process BOTH .so (Python C-extensions) and .dylib (ctypes-loaded shared
+        # libs, e.g. llama-cpp-python's libllama/libggml*). Previously only *.so
+        # was framework-ized; *.dylib fell through and shipped the archs[0]=iphoneos
+        # DEVICE build, so it failed to dlopen on the simulator.
+        for _sp_ext in so dylib; do
+        # -type f: skip SONAME symlinks (e.g. libfoo.dylib -> libfoo.1.dylib);
+        # only real Mach-O files are converted. Recipes should ship unversioned
+        # shared libs (as the flet-lib* recipes already do).
+        find "$tmp_dir/${archs[0]}" -name "*.$_sp_ext" -type f | while read full_dylib; do
             dylib_relative_path=${full_dylib#$tmp_dir/${archs[0]}/}
             create_xcframework_from_dylibs \
                 "$tmp_dir/${archs[0]}" \
                 "$tmp_dir/${archs[1]}" \
                 "$tmp_dir/${archs[2]}" \
                 $dylib_relative_path \
+                "$_sp_ext" \
                 "Frameworks/serious_python_darwin.framework/python.bundle/site-packages" \
                 $dist/site-xcframeworks
+        done
         done
 
         rm -rf $dist/site-packages

--- a/src/serious_python_darwin/darwin/xcframework_utils.sh
+++ b/src/serious_python_darwin/darwin/xcframework_utils.sh
@@ -45,8 +45,9 @@ create_xcframework_from_dylibs() {
     simulator_arm64_dir=$2
     simulator_x86_64_dir=$3
     dylib_relative_path=$4
-    origin_prefix=$5
-    out_dir=$6
+    ext=${5:-$dylib_ext}
+    origin_prefix=$6
+    out_dir=$7
 
     dylib_tmp_dir=$(mktemp -d)
     pushd -- "${dylib_tmp_dir}" >/dev/null
@@ -60,12 +61,24 @@ create_xcframework_from_dylibs() {
     done
     framework_identifier=${framework_identifier:-framework}
 
+    # If neither simulator slice has this lib, leave the file untouched rather
+    # than fail `lipo` on an empty input (e.g. a device-only artifact). It then
+    # ships as-is in the flat base, exactly as before this conversion existed.
+    if [ -z "$(find "$simulator_arm64_dir" "$simulator_x86_64_dir" \
+                    \( -path "*/$dylib_without_ext.*.$ext" -o -path "*/$dylib_without_ext.$ext" \) \
+                    -type f 2>/dev/null | head -1)" ]; then
+        echo "  no simulator slice for $dylib_relative_path; leaving as-is"
+        popd >/dev/null
+        rm -rf "${dylib_tmp_dir}" >/dev/null
+        return
+    fi
+
     # creating "iphoneos" framework
     fd=iphoneos/$framework.framework
     mkdir -p $fd
     mv "$iphone_dir/$dylib_relative_path" $fd/$framework
     echo "Frameworks/$framework.framework/$framework" > "$iphone_dir/$dylib_without_ext.fwork"
-    install_name_tool -id @rpath/$framework.framework/$framework $fd/$framework
+    if [ "$ext" = "so" ]; then install_name_tool -id @rpath/$framework.framework/$framework $fd/$framework; fi
     create_plist $framework "org.python.$framework_identifier" $fd/Info.plist
     echo "$origin_prefix/$dylib_without_ext.fwork" > $fd/$framework.origin
 
@@ -73,12 +86,12 @@ create_xcframework_from_dylibs() {
     fd=iphonesimulator/$framework.framework
     mkdir -p $fd
     lipo -create \
-        $(find "$simulator_arm64_dir" -path "$simulator_arm64_dir/$dylib_without_ext.*.$dylib_ext" -o -path "$simulator_arm64_dir/$dylib_without_ext.$dylib_ext") \
-        $(find "$simulator_x86_64_dir" -path "$simulator_x86_64_dir/$dylib_without_ext.*.$dylib_ext" -o -path "$simulator_x86_64_dir/$dylib_without_ext.$dylib_ext") \
+        $(find "$simulator_arm64_dir" -path "$simulator_arm64_dir/$dylib_without_ext.*.$ext" -o -path "$simulator_arm64_dir/$dylib_without_ext.$ext") \
+        $(find "$simulator_x86_64_dir" -path "$simulator_x86_64_dir/$dylib_without_ext.*.$ext" -o -path "$simulator_x86_64_dir/$dylib_without_ext.$ext") \
         -output $fd/$framework
-    find "$simulator_arm64_dir" -path "$simulator_arm64_dir/$dylib_without_ext.*.$dylib_ext" -o -path "$simulator_arm64_dir/$dylib_without_ext.$dylib_ext" -delete
-    find "$simulator_x86_64_dir" -path "$simulator_x86_64_dir/$dylib_without_ext.*.$dylib_ext" -o -path "$simulator_x86_64_dir/$dylib_without_ext.$dylib_ext" -delete
-    install_name_tool -id @rpath/$framework.framework/$framework $fd/$framework
+    find "$simulator_arm64_dir" -path "$simulator_arm64_dir/$dylib_without_ext.*.$ext" -o -path "$simulator_arm64_dir/$dylib_without_ext.$ext" -delete
+    find "$simulator_x86_64_dir" -path "$simulator_x86_64_dir/$dylib_without_ext.*.$ext" -o -path "$simulator_x86_64_dir/$dylib_without_ext.$ext" -delete
+    if [ "$ext" = "so" ]; then install_name_tool -id @rpath/$framework.framework/$framework $fd/$framework; fi
     create_plist $framework "org.python.$framework_identifier" $fd/Info.plist
     echo "$origin_prefix/$dylib_without_ext.fwork" > $fd/$framework.origin
 


### PR DESCRIPTION
### Problem
A Python package that ships plain `.dylib` shared libraries loaded via `ctypes` (rather than a CPython `.so` extension) fails to `dlopen` on the **iOS simulator**:

```
dlopen(.../llama_cpp/lib/libllama.dylib): mach-o file (...), but
incompatible platform (have 'iOS', need 'iOS-simulator')
```

C-extensions (numpy, stdlib) work fine on the simulator; only `.dylib`-shipping packages fail.

### Root cause
The darwin site-packages sync framework-izes only `*.so` files (`xcframework_utils.sh: dylib_ext=so`). Each `.so` becomes a **device+simulator** xcframework + a `.fwork` pointer, and Xcode extracts the correct per-slice binary — that's why C-extensions load on both device and simulator. Plain `*.dylib` files are skipped entirely and copied straight from the **device** base (`sync_site_packages.sh` copies `archs[0] = iphoneos.arm64`), so a simulator app ends up with a device-platform dylib.

The simulator/device intent never reaches this layer: `flet build ipa` and `flet build ios-simulator` both call `serious_python … --platform iOS`; they only diverge later at `flutter build ios --simulator`. So the fix has to make the `.dylib` path platform-correct on its own.

### Fix (2 files, `serious_python_darwin/darwin/`)
- `sync_site_packages.sh`: iterate **both** `so` and `dylib` in the conversion loop, passing the extension to the helper.
- `xcframework_utils.sh`: take the extension as a parameter and use it for the simulator-slice globs, so `.dylib` libs get the same device+fat-simulator xcframework + `.fwork` as `.so`.
- **Preserve the install-name for `.dylib`** (gate the `install_name_tool -id` rewrite on `ext=so`). This is the key to **multi-lib** ctypes packages: e.g. `libllama` has `LC_LOAD_DYLIB @rpath/libggml.dylib`. Keeping the install-name lets a wrapper that preloads its dependency libs with `RTLD_GLOBAL` satisfy those loads via dyld's already-loaded-image match. Rewriting the id to the framework path (the `.so` behavior) would break that.

### Non-regression / blast radius
- The `.so` path is **byte-for-byte unchanged** (`ext=so` keeps the id-rewrite) — verified numpy/stdlib frameworks are identical.
- The change **only activates on `.dylib`**. The `flet-lib*` ctypes recipes all ship a single unversioned `lib*.so` on purpose, so nothing shipping today produces a `.dylib` — this is purely additive.
- Guards for future `.dylib` recipes: `-type f` skips SONAME symlink chains, and conversion is skipped when a lib has no simulator slice (avoids an empty `lipo`), leaving it as-is.

### Testing
- `llama-cpp-python` on the **iOS simulator** (arm64): `import` + native ctypes calls + **real GGUF inference** all pass (previously the platform-mismatch `dlopen` failure). Verified against a normally-built app on both the published `1.0.1` darwin scripts and **this branch's scripts**.
- **`.so` non-regression:** numpy frameworks unchanged (id still rewritten to the framework path).
- **Device slice** validated statically from the intermediate xcframework (`ios-arm64`: `platform 2`, install-names preserved, inter-lib deps intact). Device runtime / code-signing not verified on hardware — the `.dylib`→framework path uses the same Xcode embed/sign as the existing `.so` framework path.

### Proposed CHANGELOG change
```
* darwin: also package ctypes `.dylib` shared libs as per-slice xcframeworks on
  iOS (previously only `.so` C-extensions), so they load on the simulator;
  preserve their install-name so multi-lib packages resolve their siblings.
```
