### PR TITLE
ci: cut GitHub Release on tag runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,3 +607,31 @@ jobs:
           publish_pkg src/serious_python_linux
           sleep 600
           publish_pkg src/serious_python
+
+  release:
+    name: Publish GitHub Release
+    needs:
+      - publish
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    permissions:
+      contents: write
+    steps:
+      - name: Detect pre-release
+        id: prerelease
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "$REF_NAME" == *-* ]]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        with:
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          prerelease: ${{ steps.prerelease.outputs.is_prerelease == 'true' }}
+          generate_release_notes: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           restore-keys: |
             flet-cache-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python_version }}-
             flet-cache-${{ runner.os }}-${{ runner.arch }}-
-          # Read-only on tag/release builds to avoid cache poisoning.
+          # Avoid release-time cache poisoning.
           lookup-only: ${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: Configure ${{ matrix.build_system }}
@@ -170,7 +170,7 @@ jobs:
           restore-keys: |
             flet-cache-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python_version }}-
             flet-cache-${{ runner.os }}-${{ runner.arch }}-
-          # Read-only on tag/release builds to avoid cache poisoning.
+          # Avoid release-time cache poisoning.
           lookup-only: ${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: Setup iOS Simulator
@@ -254,7 +254,7 @@ jobs:
           restore-keys: |
             flet-cache-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python_version }}-
             flet-cache-${{ runner.os }}-${{ runner.arch }}-
-          # Read-only on tag/release builds to avoid cache poisoning.
+          # Avoid release-time cache poisoning.
           lookup-only: ${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: Enable KVM
@@ -270,7 +270,7 @@ jobs:
         # v5 was the last fully MIT-licensed major and is on Node 24.
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
-          # Disable the Gradle cache on tag/release builds to avoid cache poisoning.
+          # Avoid release-time cache poisoning.
           cache-disabled: ${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: AVD cache
@@ -281,7 +281,7 @@ jobs:
             ~/.android/avd/*
             ~/.android/adb*
           key: avd-bridge
-          # Read-only on tag/release builds to avoid cache poisoning.
+          # Avoid release-time cache poisoning.
           lookup-only: ${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: Setup Android Emulator + Run tests
@@ -362,7 +362,7 @@ jobs:
           restore-keys: |
             flet-cache-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python_version }}-
             flet-cache-${{ runner.os }}-${{ runner.arch }}-
-          # Read-only on tag/release builds to avoid cache poisoning.
+          # Avoid release-time cache poisoning.
           lookup-only: ${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: Package + run integration test
@@ -537,8 +537,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          # Publish runs on tags; disable the uv cache there to avoid
-          # release-time cache poisoning.
+          # Avoid release-time cache poisoning.
           enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
       - name: Setup Flutter
@@ -619,6 +618,8 @@ jobs:
     steps:
       - name: Detect pre-release
         id: prerelease
+        # Dart/pub pre-releases carry a semver hyphen suffix (e.g. v1.2.0-beta.1);
+        # mark those as GitHub pre-releases.
         env:
           REF_NAME: ${{ github.ref_name }}
         run: |


### PR DESCRIPTION
Adds a `release` job to CI that publishes a **GitHub Release** for `v*` tag runs, mirroring the release step in `flet` and `python-build`.

On a `v*` tag push, once the existing `publish` job has put all six packages live on pub.dev, `release` creates a GitHub Release for the tag with auto-generated notes. Nothing changes for branch/PR builds.