### PR TITLE
Bump to 4.3.0: Windows CRT WOW64/Sysnative fix (flet #6436)

### DIFF
--- a/src/serious_python/CHANGELOG.md
+++ b/src/serious_python/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.0
+
+* **Windows:** fix `flet build windows` failing with `file INSTALL cannot find "C:/WINDOWS/System32/vcruntime140_1.dll"` for users who build with VS Build Tools rather than full Visual Studio (a WOW64 file-system-redirection issue with the bundled 32-bit cmake). See `serious_python_windows` 4.3.0.
+
 ## 4.2.1
 
 * **iOS/macOS:** ctypes packages that ship plain `.dylib` shared libraries (e.g. `llama-cpp-python`'s `libllama` / `libggml`) now load on the **iOS simulator**. Such `.dylib`s are now packaged as per-slice xcframeworks (previously only `.so` C-extensions were), so they carry a simulator slice instead of shipping the device build and failing `dlopen` with `incompatible platform (have 'iOS', need 'iOS-simulator')`; their install-name is preserved so multi-lib packages still resolve their sibling libs. See `serious_python_darwin` 4.2.1.

--- a/src/serious_python/pubspec.yaml
+++ b/src/serious_python/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python
 description: A cross-platform plugin for adding embedded Python runtime to your Flutter apps.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.2.1
+version: 4.3.0
 
 platforms:
   ios:

--- a/src/serious_python_android/CHANGELOG.md
+++ b/src/serious_python_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.0
+
+* Version bump aligning with the `serious_python_*` 4.3.0 release.
+
 ## 4.2.1
 
 * Bump the bundled python-build snapshot to `20260701`; aligns with the `serious_python_*` 4.2.1 release. The Android runtimes are byte-identical to `20260630` (the release only rebuilds the iOS runtime).

--- a/src/serious_python_android/android/build.gradle.kts
+++ b/src/serious_python_android/android/build.gradle.kts
@@ -21,7 +21,7 @@ buildscript {
 }
 
 group = "com.flet.serious_python_android"
-version = "4.2.1"
+version = "4.3.0"
 
 rootProject.allprojects {
     repositories {

--- a/src/serious_python_android/pubspec.yaml
+++ b/src/serious_python_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_android
 description: Android implementation of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.2.1
+version: 4.3.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/src/serious_python_darwin/CHANGELOG.md
+++ b/src/serious_python_darwin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.0
+
+* Version bump aligning with the `serious_python_*` 4.3.0 release.
+
 ## 4.2.1
 
 * Framework-ize ctypes `.dylib` shared libs (not just `.so` C-extensions) when syncing iOS site-packages, so `.dylib`-shipping packages (e.g. `llama-cpp-python`) load on the **iOS simulator** instead of failing `dlopen` with `incompatible platform (have 'iOS', need 'iOS-simulator')`. Each `.dylib` becomes a device+simulator xcframework + `.fwork` pointer, exactly like `.so`; unlike `.so` (whose id is rewritten to the framework path), the `.dylib` install-name is preserved so multi-lib packages resolve their sibling libs. The `.so` path is unchanged.

--- a/src/serious_python_darwin/darwin/serious_python_darwin.podspec
+++ b/src/serious_python_darwin/darwin/serious_python_darwin.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'serious_python_darwin'
-  s.version          = '4.2.1'
+  s.version          = '4.3.0'
   s.summary          = 'A cross-platform plugin for adding embedded Python runtime to your Flutter apps.'
   s.description      = <<-DESC
   A cross-platform plugin for adding embedded Python runtime to your Flutter apps.

--- a/src/serious_python_darwin/pubspec.yaml
+++ b/src/serious_python_darwin/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_darwin
 description: iOS and macOS implementations of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.2.1
+version: 4.3.0
 
 environment:
   # The Swift Package Manager build path needs Flutter 3.44 / Dart 3.11 (the

--- a/src/serious_python_linux/CHANGELOG.md
+++ b/src/serious_python_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.0
+
+* Version bump aligning with the `serious_python_*` 4.3.0 release.
+
 ## 4.2.1
 
 * Bump the bundled python-build snapshot to `20260701`; aligns with the `serious_python_*` 4.2.1 release. The Linux runtimes are byte-identical to `20260630` (the release only rebuilds the iOS runtime).

--- a/src/serious_python_linux/pubspec.yaml
+++ b/src/serious_python_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_linux
 description: Linux implementations of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.2.1
+version: 4.3.0
 
 environment:
   sdk: '>=3.1.3 <4.0.0'

--- a/src/serious_python_platform_interface/CHANGELOG.md
+++ b/src/serious_python_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.0
+
+* Version bump aligning with the `serious_python_*` 4.3.0 release.
+
 ## 4.2.1
 
 * Version bump aligning with the `serious_python_*` 4.2.1 release.

--- a/src/serious_python_platform_interface/pubspec.yaml
+++ b/src/serious_python_platform_interface/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_platform_interface
 description: A common platform interface for the serious_python plugin.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.2.1
+version: 4.3.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/src/serious_python_windows/CHANGELOG.md
+++ b/src/serious_python_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.0
+
+* **Fix `flet build windows` failing with `file INSTALL cannot find "C:/WINDOWS/System32/vcruntime140_1.dll"`** for users who have VS Build Tools installed rather than full Visual Studio. The plugin harvests the CRT runtime DLLs (`msvcp140.dll` / `vcruntime140.dll` / `vcruntime140_1.dll`) from `%WINDIR%\System32`, but Flutter drives the CMake install step with the **32-bit** `cmake.exe` bundled in VS Build Tools. Under WOW64 file-system redirection that process sees `System32` transparently rewritten to `SysWOW64`, which holds the x86 CRT and doesn't contain `vcruntime140_1.dll` at all — so the x64 build copied wrong-arch DLLs and then failed. The CRT directory is now resolved via the `Sysnative` pseudo-folder (visible only to 32-bit processes, mapping back to the real 64-bit `System32`) when present, falling back to `System32` for native 64-bit cmake. See flet-dev/flet#6436.
+
 ## 4.2.1
 
 * Bump the bundled python-build snapshot to `20260701`; aligns with the `serious_python_*` 4.2.1 release. The Windows runtimes are byte-identical to `20260630` (the release only rebuilds the iOS runtime).

--- a/src/serious_python_windows/pubspec.yaml
+++ b/src/serious_python_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_windows
 description: Windows implementations of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.2.1
+version: 4.3.0
 
 environment:
   sdk: '>=3.1.3 <4.0.0'

--- a/src/serious_python_windows/windows/CMakeLists.txt
+++ b/src/serious_python_windows/windows/CMakeLists.txt
@@ -190,13 +190,31 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
 # This list could contain prebuilt libraries, or libraries created by an
 # external build triggered from this build file.
 string(REPLACE "\\" "/" SERIOUS_PYTHON_WINDIR "$ENV{WINDIR}")
+
+# CRT runtime DLLs (msvcp140 / vcruntime140 / vcruntime140_1) are harvested from
+# the OS's 64-bit System32. Flutter may drive the CMake install step with the
+# 32-bit cmake.exe bundled in VS Build Tools (users without full Visual Studio).
+# Under WOW64 file-system redirection a 32-bit process sees C:\Windows\System32
+# transparently rewritten to SysWOW64, which holds the x86 CRT and doesn't
+# contain vcruntime140_1.dll at all — so the x64 build copies wrong-arch DLLs and
+# then fails with "cannot find vcruntime140_1.dll" (flet-dev/flet#6436).
+# "Sysnative" is the documented pseudo-folder that maps a 32-bit process back to
+# the real 64-bit System32; it's visible only to 32-bit processes, so a native
+# 64-bit cmake has no Sysnative and keeps using System32. Configure- and
+# install-time cmake are the same binary under Flutter, so the path resolved here
+# stays valid when cmake_install.cmake later runs.
+set(_sp_crt_dir "${SERIOUS_PYTHON_WINDIR}/System32")
+if(EXISTS "${SERIOUS_PYTHON_WINDIR}/Sysnative")
+  set(_sp_crt_dir "${SERIOUS_PYTHON_WINDIR}/Sysnative")
+endif()
+
 set(serious_python_windows_bundled_libraries
   "${PYTHON_PACKAGE}/python${PYTHON_VERSION_NODOT}$<$<CONFIG:Debug>:_d>.dll"
   "${PYTHON_PACKAGE}/python3$<$<CONFIG:Debug>:_d>.dll"
   "$<IF:$<CONFIG:Debug>,${DART_BRIDGE_DEBUG_DLL},${DART_BRIDGE_RELEASE_DLL}>"
-  "${SERIOUS_PYTHON_WINDIR}/System32/msvcp140.dll"
-  "${SERIOUS_PYTHON_WINDIR}/System32/vcruntime140.dll"
-  "${SERIOUS_PYTHON_WINDIR}/System32/vcruntime140_1.dll"
+  "${_sp_crt_dir}/msvcp140.dll"
+  "${_sp_crt_dir}/vcruntime140.dll"
+  "${_sp_crt_dir}/vcruntime140_1.dll"
   PARENT_SCOPE
 )
 


### PR DESCRIPTION
Prepares the **4.3.0** release. All `serious_python_*` packages bumped 4.2.1 → 4.3.0. The one substantive change is the Windows CRT fix below; every other platform is an alignment-only bump. No python-build snapshot re-pin.

## The Windows fix

`flet build windows` fails during the CMake install step with:

```
CMake Error at cmake_install.cmake:266 (file):
  file INSTALL cannot find "C:/WINDOWS/System32/vcruntime140_1.dll"
```

…for users who have **VS Build Tools** (not full Visual Studio) installed.

### Root cause

This plugin bundles the CRT runtime DLLs (`msvcp140.dll`, `vcruntime140.dll`, `vcruntime140_1.dll`) by harvesting them from `%WINDIR%\System32`. Flutter drives the install step with the **32-bit `cmake.exe`** bundled in VS Build Tools. Under WOW64 file-system redirection a 32-bit process transparently sees `C:\Windows\System32` rewritten to `C:\Windows\SysWOW64`, which:

- holds the **x86** copies of `msvcp140.dll` / `vcruntime140.dll` (wrong arch for the x64 build — they get copied but are broken), and
- does **not** contain `vcruntime140_1.dll` at all → hard "file not found" failure.

With full Visual Studio the bundled cmake is 64-bit, no redirection happens, and the build works — which is exactly the "install full VS" workaround reported in the issue.

### Fix

Prefer the **`Sysnative`** pseudo-folder, which is visible only to 32-bit processes and maps back to the real 64-bit `System32`. Native 64-bit cmake has no `Sysnative`, so it falls back to `System32` unchanged. Configure- and install-time cmake are the same binary under Flutter, so the path resolved at configure time stays valid when `cmake_install.cmake` runs.

## Testing

⚠️ **Needs validation on Windows with VS Build Tools only (no full VS)** — the environment that reproduces the failure. Full-VS and 64-bit-cmake paths are unaffected (they skip the `Sysnative` branch).

Fixes flet-dev/flet#6436 (also relates to flet-dev/flet#5205, flet-dev/flet#3107).