### PR TITLE
Bump to 4.3.1: Android x86_64 empty sitepackages.zip fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,7 +612,7 @@ jobs:
     needs:
       - publish
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ !cancelled() && needs.publish.result == 'success' && startsWith(github.ref, 'refs/tags/v') }}
     permissions:
       contents: write
     steps:

--- a/src/serious_python/CHANGELOG.md
+++ b/src/serious_python/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.1
+
+* **Android:** fix `flet build apk --arch x86_64` (or any `--arch` subset not including `arm64-v8a`) producing an APK with an **empty `sitepackages.zip`** — the app shipped without its Python dependencies and the first import failed at startup. See `serious_python_android` 4.3.1.
+
 ## 4.3.0
 
 * **Desktop multiprocessing support** ([flet-dev/flet#4283](https://github.com/flet-dev/flet/issues/4283)). `dart_bridge` **1.5.0** adds `serious_python_is_mp_invocation` / `serious_python_main` (+ `_w` wide-char variants on Windows): host apps call them first thing in `main` to detect CPython child command lines (`--multiprocessing-fork`, `-c "from multiprocessing..."` — spawn workers, the resource tracker, and the forkserver) and service them as a plain headless interpreter (`Py_Main`/`Py_BytesMain`, stable ABI) instead of re-launching the GUI. The exports rely on the `PYTHONHOME`/`PYTHONPATH` the parent already stamped process-wide.

--- a/src/serious_python/pubspec.yaml
+++ b/src/serious_python/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python
 description: A cross-platform plugin for adding embedded Python runtime to your Flutter apps.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.3.0
+version: 4.3.1
 
 platforms:
   ios:

--- a/src/serious_python_android/CHANGELOG.md
+++ b/src/serious_python_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.1
+
+* Fix `flet build apk --arch <abi>` shipping an **empty `sitepackages.zip`** whenever the selected ABI subset didn't include `arm64-v8a` (e.g. `--arch x86_64`) — the app bundled no Python site-packages at all and the very first dependency import failed at startup. The ABI-common pure-code zips (`sitepackages.zip` / `extract.zip`) were built from a hardcoded primary ABI (`abis.first()`, i.e. `arm64-v8a`); when only other ABIs were staged under `SERIOUS_PYTHON_SITE_PACKAGES`, the primary split task walked a nonexistent directory and silently produced a valid-but-empty zip. The primary ABI is now the first manifest ABI whose site-packages tree was actually staged. If none is staged at all (legitimate when packaging with no requirements), the build falls back to `abis.first()` and logs `sitepackages.zip will be empty` instead of staying silent.
+
 ## 4.3.0
 
 * `PYTHONINSPECT=1` is no longer set by any platform implementation. It had no effect on the embedded interpreter, but it leaked into the process environment where any *real* interpreter child (e.g. a serviced multiprocessing worker) would inherit it and hang in interactive mode after its command completed. No functional change on Android, which doesn't support process spawning.

--- a/src/serious_python_android/android/build.gradle.kts
+++ b/src/serious_python_android/android/build.gradle.kts
@@ -21,7 +21,7 @@ buildscript {
 }
 
 group = "com.flet.serious_python_android"
-version = "4.3.0"
+version = "4.3.1"
 
 rootProject.allprojects {
     repositories {
@@ -136,7 +136,18 @@ val extractGlobs: List<Regex> =
     extractPackages.filter { '*' in it || '?' in it }.map(::globToRegex)
 val extractPlain: List<String> =
     extractPackages.filter { '*' !in it && '?' !in it }
-val primaryAbi = abis.first()                       // pure zips are ABI-common: build once
+// Pure zips are ABI-common: build once, from the first ABI whose site-packages
+// tree was actually staged — `flet build --arch` may stage a subset of the ABIs
+// (e.g. only x86_64), and a hardcoded abis.first() would then walk a missing
+// dir and silently ship an EMPTY sitepackages.zip. No staged dir at all is
+// legitimate (packaged with no requirements): fall back to abis.first(), whose
+// empty walk correctly yields empty zips.
+val primaryAbi = abis.firstOrNull { siteSrcDir != null && File(siteSrcDir, it).isDirectory }
+    ?: abis.first().also {
+        logger.lifecycle(
+            "serious_python: no staged site-packages under $siteSrcDir; " +
+            "sitepackages.zip will be empty")
+    }
 val assetsDir = file("src/main/assets")
 val bootstrapPy = file("../python/_sp_bootstrap.py")
 

--- a/src/serious_python_android/pubspec.yaml
+++ b/src/serious_python_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_android
 description: Android implementation of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.3.0
+version: 4.3.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/src/serious_python_darwin/CHANGELOG.md
+++ b/src/serious_python_darwin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.1
+
+* Version bump aligning with the `serious_python_*` 4.3.1 release.
+
 ## 4.3.0
 
 * Bump `dart_bridge` to **1.5.0** (python-build snapshot `20260708`): multiprocessing child-interception exports (`serious_python_is_mp_invocation` / `serious_python_main`), kept alive against the host link's `-dead_strip` both by `__attribute__((used))` in the archive and by keep-alive references in `SeriousPythonPlugin.swift`. See the `serious_python` 4.3.0 notes.

--- a/src/serious_python_darwin/darwin/serious_python_darwin.podspec
+++ b/src/serious_python_darwin/darwin/serious_python_darwin.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'serious_python_darwin'
-  s.version          = '4.3.0'
+  s.version          = '4.3.1'
   s.summary          = 'A cross-platform plugin for adding embedded Python runtime to your Flutter apps.'
   s.description      = <<-DESC
   A cross-platform plugin for adding embedded Python runtime to your Flutter apps.

--- a/src/serious_python_darwin/pubspec.yaml
+++ b/src/serious_python_darwin/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_darwin
 description: iOS and macOS implementations of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.3.0
+version: 4.3.1
 
 environment:
   # The Swift Package Manager build path needs Flutter 3.44 / Dart 3.11 (the

--- a/src/serious_python_linux/CHANGELOG.md
+++ b/src/serious_python_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.1
+
+* Version bump aligning with the `serious_python_*` 4.3.1 release.
+
 ## 4.3.0
 
 * Bump `dart_bridge` to **1.5.0** (python-build snapshot `20260708`): multiprocessing child-interception exports (`serious_python_is_mp_invocation` / `serious_python_main`), consumed by the flet build template's `main.cc` via `dlopen("libdart_bridge.so")`. Relevant on Linux since Python 3.14 made `forkserver` (which execs `sys.executable`) the default start method. See the `serious_python` 4.3.0 notes.

--- a/src/serious_python_linux/pubspec.yaml
+++ b/src/serious_python_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_linux
 description: Linux implementations of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.3.0
+version: 4.3.1
 
 environment:
   sdk: '>=3.1.3 <4.0.0'

--- a/src/serious_python_platform_interface/CHANGELOG.md
+++ b/src/serious_python_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.1
+
+* Version bump aligning with the `serious_python_*` 4.3.1 release.
+
 ## 4.3.0
 
 * Version bump aligning with the `serious_python_*` 4.3.0 release.

--- a/src/serious_python_platform_interface/pubspec.yaml
+++ b/src/serious_python_platform_interface/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_platform_interface
 description: A common platform interface for the serious_python plugin.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.3.0
+version: 4.3.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/src/serious_python_windows/CHANGELOG.md
+++ b/src/serious_python_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.1
+
+* Version bump aligning with the `serious_python_*` 4.3.1 release.
+
 ## 4.3.0
 
 * Bump `dart_bridge` to **1.5.0** (python-build snapshot `20260708`): multiprocessing child-interception exports, including the Windows wide-char variants `serious_python_is_mp_invocation_w` / `serious_python_main_w` (→ `Py_Main`) consumed by the flet build template's `wWinMain`. See the `serious_python` 4.3.0 notes.

--- a/src/serious_python_windows/pubspec.yaml
+++ b/src/serious_python_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_windows
 description: Windows implementations of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.3.0
+version: 4.3.1
 
 environment:
   sdk: '>=3.1.3 <4.0.0'


### PR DESCRIPTION
## Problem

`flet build apk --arch x86_64` (any `--arch` subset not including `arm64-v8a`) produced an APK with an **empty `sitepackages.zip`**: the app shipped with no Python site-packages at all, and the bootstrap's very first dependency import (e.g. `import certifi`) failed at startup. Reported against flet 0.86.0.dev2 / serious_python 4.3.0.

## Root cause

Since the 4.3.0 native-mmap packaging, the pure-code zips (`sitepackages.zip` / `extract.zip`) are ABI-common assets built **once from a "primary" ABI**, hardcoded as `abis.first()` from `python_versions.properties` — always `arm64-v8a`. With `--arch x86_64`, flet stages only `build/site-packages/x86_64/`; the primary split task then walks the nonexistent `arm64-v8a/` dir (Kotlin's `walkTopDown()` on a missing root yields nothing) and silently writes a valid-but-empty stored zip. The default build worked only because it happens to stage `arm64-v8a`.

## Fix

`primaryAbi` is now the first manifest ABI whose per-ABI tree actually exists under `SERIOUS_PYTHON_SITE_PACKAGES`. If none is staged — legitimate when packaging with **no requirements** (the package command skips staging entirely, so this must not be an error) — fall back to `abis.first()`, whose empty walk correctly yields empty zips, and log `sitepackages.zip will be empty` so that state is visible in the build log instead of silent.

No flet-cli change needed: Gradle infers the staged ABI set on its own.

## Verification

Reproduced the failing scenario locally with `run_example`:

1. `dart run serious_python:main package app/src -p Android --arch x86_64 ...` → only `build/site-packages/x86_64/` staged (no `arm64-v8a/`).
2. `flutter build apk --debug --target-platform android-x64` → before the fix this produced a ~22-byte `sitepackages.zip`; after the fix it's **25 MB**, containing `numpy`, `jnius`, `lru` + dist-infos, with 21 `.soref` markers resolving to 83 relocated native libs in `lib/x86_64/`.

## Release

Standard aligned bump of all six packages to 4.3.1; only `serious_python_android` has a substantive change, the rest are alignment-only CHANGELOG entries. Prepared per the release process — **not tagged/published**.