### PR TITLE
Bump to 4.3.4: Android `flet debug` stale-code fix (flet #6682)

### DIFF
--- a/src/serious_python/CHANGELOG.md
+++ b/src/serious_python/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.3.4
+
+* **Android:** fix code edits not taking effect under `flet debug android` — the app kept running stale code after a re-run because the on-device extraction cache wasn't invalidated by a same-version reinstall. See `serious_python_android` 4.3.4 and flet-dev/flet#6682.
+* No runtime changes: bundled Python versions (**3.12.13 / 3.13.14 / 3.14.6**) and `dart_bridge` (**1.5.0**) are unchanged from 4.3.3.
+
 ## 4.3.3
 
 * **Windows:** fix `flet build windows` failing on non-UTF-8 system locales (e.g. Simplified-Chinese Windows, code page **936/GBK**) with `error C2220` (escalated from `warning C4819`) while compiling the Windows plugin — a non-ASCII character in a source comment couldn't be decoded under GBK and the Flutter template's `/WX` made it fatal. The character is removed and the plugin now builds with `/utf-8`. See `serious_python_windows` 4.3.3 and flet-dev/flet#6686.

--- a/src/serious_python/pubspec.yaml
+++ b/src/serious_python/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python
 description: A cross-platform plugin for adding embedded Python runtime to your Flutter apps.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.3.3
+version: 4.3.4
 
 platforms:
   ios:

--- a/src/serious_python_android/CHANGELOG.md
+++ b/src/serious_python_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.4
+
+* **Android:** fix code edits not taking effect under `flet debug android` — the app kept running the previously-unpacked, stale code after a re-run ([flet-dev/flet#6682](https://github.com/flet-dev/flet/issues/6682)). `prepareApp` copies the app payload out of the APK only when its cache key changes, and the key was `versionName+versionCode`. Since `flet debug` reinstalls the same-version APK on each iteration (`flutter run` does an update install that preserves app data, including the cache marker), the key never changed and re-extraction was skipped. The key now also includes `PackageManager.lastUpdateTime`, which is bumped on every (re)install but stays stable across plain relaunches — so a debug reinstall re-extracts the new code while ordinary relaunches still hit the cache. `flet build apk` was unaffected (fresh/version-bumped install).
+
 ## 4.3.3
 
 * Version bump aligning with the `serious_python_*` 4.3.3 release (a Windows build fix). No Android-affecting changes.

--- a/src/serious_python_android/android/build.gradle.kts
+++ b/src/serious_python_android/android/build.gradle.kts
@@ -21,7 +21,7 @@ buildscript {
 }
 
 group = "com.flet.serious_python_android"
-version = "4.3.3"
+version = "4.3.4"
 
 rootProject.allprojects {
     repositories {

--- a/src/serious_python_android/android/src/main/java/com/flet/serious_python_android/AndroidPlugin.java
+++ b/src/serious_python_android/android/src/main/java/com/flet/serious_python_android/AndroidPlugin.java
@@ -132,7 +132,16 @@ public class AndroidPlugin implements FlutterPlugin, MethodCallHandler, Activity
         long versionCode = (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P)
             ? info.getLongVersionCode()
             : (long) info.versionCode;
-        result.success(versionName + "+" + versionCode);
+        // Append lastUpdateTime so the value changes on every (re)install, not
+        // just on a version bump. `flet debug android` reinstalls the same
+        // versionName+versionCode APK on each iteration (`flutter run` does an
+        // update install that preserves app data), so without this the
+        // extraction cache key in prepareApp never changes and the app keeps
+        // running the previously-unpacked, stale code. PackageManager bumps
+        // lastUpdateTime on each install while leaving it stable across plain
+        // relaunches, so the cache is still hit when nothing was reinstalled.
+        long lastUpdateTime = info.lastUpdateTime;
+        result.success(versionName + "+" + versionCode + "+" + lastUpdateTime);
       } catch (Exception e) {
         result.error("Error", e.getMessage(), null);
       }

--- a/src/serious_python_android/lib/serious_python_android.dart
+++ b/src/serious_python_android/lib/serious_python_android.dart
@@ -45,6 +45,11 @@ class SeriousPythonAndroid extends SeriousPythonPlatform {
     final siteZip = p.join(base, 'sitepackages.zip');
     final extractDir = p.join(base, 'extract');
 
+    // `getAppVersion` returns `versionName+versionCode+lastUpdateTime`, so the
+    // key changes on every (re)install — including `flet debug`'s repeated
+    // same-version `flutter run` reinstalls — while staying stable across plain
+    // relaunches. Keeping only versionName+versionCode here would make the
+    // debug workflow keep running previously-unpacked, stale app code.
     final appVersion = await _appVersion();
     final key = appVersion != null ? 'app:$appVersion' : 'app:dev';
     final marker = File(p.join(base, '.key'));

--- a/src/serious_python_android/pubspec.yaml
+++ b/src/serious_python_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_android
 description: Android implementation of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.3.3
+version: 4.3.4
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/src/serious_python_darwin/CHANGELOG.md
+++ b/src/serious_python_darwin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.4
+
+* Version bump aligning with the `serious_python_*` 4.3.4 release (an Android `flet debug` cache fix). No iOS/macOS-affecting changes.
+
 ## 4.3.3
 
 * Version bump aligning with the `serious_python_*` 4.3.3 release (a Windows build fix). No iOS/macOS-affecting changes.

--- a/src/serious_python_darwin/darwin/serious_python_darwin.podspec
+++ b/src/serious_python_darwin/darwin/serious_python_darwin.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'serious_python_darwin'
-  s.version          = '4.3.3'
+  s.version          = '4.3.4'
   s.summary          = 'A cross-platform plugin for adding embedded Python runtime to your Flutter apps.'
   s.description      = <<-DESC
   A cross-platform plugin for adding embedded Python runtime to your Flutter apps.

--- a/src/serious_python_darwin/pubspec.yaml
+++ b/src/serious_python_darwin/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_darwin
 description: iOS and macOS implementations of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.3.3
+version: 4.3.4
 
 environment:
   # The Swift Package Manager build path needs Flutter 3.44 / Dart 3.11 (the

--- a/src/serious_python_linux/CHANGELOG.md
+++ b/src/serious_python_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.4
+
+* Version bump aligning with the `serious_python_*` 4.3.4 release (an Android `flet debug` cache fix). No Linux-affecting changes.
+
 ## 4.3.3
 
 * Remove a stray non-ASCII character (an em dash) from a source comment in `serious_python_linux_plugin.cc` — GCC reads UTF-8 sources by default so there was no build impact, but it mirrors the Windows fix (flet-dev/flet#6686). Version bump aligning with the `serious_python_*` 4.3.3 release; no Linux-affecting runtime changes.

--- a/src/serious_python_linux/pubspec.yaml
+++ b/src/serious_python_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_linux
 description: Linux implementations of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.3.3
+version: 4.3.4
 
 environment:
   sdk: '>=3.1.3 <4.0.0'

--- a/src/serious_python_platform_interface/CHANGELOG.md
+++ b/src/serious_python_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.4
+
+* Version bump aligning with the `serious_python_*` 4.3.4 release (an Android `flet debug` cache fix).
+
 ## 4.3.3
 
 * Version bump aligning with the `serious_python_*` 4.3.3 release.

--- a/src/serious_python_platform_interface/pubspec.yaml
+++ b/src/serious_python_platform_interface/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_platform_interface
 description: A common platform interface for the serious_python plugin.
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.3.3
+version: 4.3.4
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/src/serious_python_windows/CHANGELOG.md
+++ b/src/serious_python_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.4
+
+* Version bump aligning with the `serious_python_*` 4.3.4 release (an Android `flet debug` cache fix). No Windows-affecting changes.
+
 ## 4.3.3
 
 * **Fix `flet build windows` failing on non-UTF-8 system locales** with `warning C4819` escalated to `error C2220` while compiling `serious_python_windows_plugin.cpp` (flet-dev/flet#6686). A source comment contained a non-ASCII character (an em dash); on a system whose code page isn't UTF-8 — e.g. code page **936/GBK** on Simplified-Chinese Windows — MSVC decodes the UTF-8 source as GBK, can't represent the byte sequence (C4819), and the Flutter template's `/WX` (warnings-as-errors) turns it into a fatal C2220. The character is removed, and the plugin now compiles with `/utf-8` so any future non-ASCII source byte is read correctly regardless of the build machine's code page. Bundled Python and `dart_bridge` versions are unchanged from 4.3.2.

--- a/src/serious_python_windows/pubspec.yaml
+++ b/src/serious_python_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: serious_python_windows
 description: Windows implementations of the serious_python plugin
 homepage: https://flet.dev
 repository: https://github.com/flet-dev/serious-python
-version: 4.3.3
+version: 4.3.4
 
 environment:
   sdk: '>=3.1.3 <4.0.0'


### PR DESCRIPTION
## Summary

Fixes [flet-dev/flet#6682](https://github.com/flet-dev/flet/issues/6682) — code edits not taking effect under `flet debug android`.

`flet debug android` re-packages the app, rebuilds the APK, and `flutter run -d <device>` reinstalls it, so the new code **is** inside the freshly installed APK's assets. But on Android, `prepareApp` copies the app payload out of the APK to a writable dir **only when a cache key changes**, and that key was `versionName+versionCode` (e.g. `1.0.0+1`).

`flet debug` never bumps the version between iterations, and `flutter run` does an *update* install that preserves app data — including the `.key` cache marker and the previously-unpacked `app/` dir. So the key never changed → re-extraction was skipped → the app kept running **stale** code.

This is Android-only: iOS/desktop run the app straight from the read-only app bundle, which `flutter run` fully replaces each reinstall. `flet build apk` was unaffected (fresh/version-bumped install).

## Fix

`getAppVersion` now appends `PackageManager.lastUpdateTime` to the returned version string. It's bumped on every (re)install but stays stable across plain relaunches — so a `flet debug` reinstall invalidates the extraction cache and unpacks the new code, while ordinary relaunches still hit the cache with no per-launch cost.

- `AndroidPlugin.java` — append `+ lastUpdateTime` to the `getAppVersion` result.
- `serious_python_android.dart` — comment documenting why the cache key depends on that reinstall-sensitive value (the Dart side treats the string as opaque, so no logic change).

## Release

Bumps all six packages to **4.3.4**. No python-build snapshot change — bundled Python (3.12.13 / 3.13.14 / 3.14.6) and `dart_bridge` (1.5.0) are unchanged from 4.3.3. CHANGELOG: substantive entry in `serious_python_android`, cross-referenced summary in `serious_python`, alignment lines elsewhere.

## Verification

Not exercised on a device in this change. Suggested end-to-end check: `flet debug android` → confirm app shows → edit `main.py` → `flet debug android` again → confirm the edit now appears (previously it wouldn't).