### PR TITLE
examples: pin jni to 1.0.0 (1.0.1 breaks aarch64 Linux builds)

### DIFF
--- a/src/serious_python/example/bridge_example/pubspec.yaml
+++ b/src/serious_python/example/bridge_example/pubspec.yaml
@@ -24,5 +24,14 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^2.0.0
 
+# jni arrives transitively (path_provider -> path_provider_android ->
+# jni_flutter -> jni). 1.0.1 added global_jni_env.c, which passes a `va_list`
+# where a `void *` is expected: fine on x86_64, where va_list is an array type
+# that decays to a pointer, but a hard error on aarch64, where it's a struct.
+# That breaks `flutter build linux` on ARM64 hosts. Tracked upstream at
+# dart-lang/native#3498 — drop this override once a fixed jni is released.
+dependency_overrides:
+  jni: 1.0.0
+
 flutter:
   uses-material-design: true

--- a/src/serious_python/example/flask_example/pubspec.lock
+++ b/src/serious_python/example/flask_example/pubspec.lock
@@ -156,7 +156,7 @@ packages:
     source: hosted
     version: "4.1.2"
   jni:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: jni
       sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
@@ -361,42 +361,42 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "4.0.0"
+    version: "4.4.1"
   serious_python_android:
     dependency: transitive
     description:
       path: "../../../serious_python_android"
       relative: true
     source: path
-    version: "4.0.0"
+    version: "4.4.1"
   serious_python_darwin:
     dependency: transitive
     description:
       path: "../../../serious_python_darwin"
       relative: true
     source: path
-    version: "4.0.0"
+    version: "4.4.1"
   serious_python_linux:
     dependency: transitive
     description:
       path: "../../../serious_python_linux"
       relative: true
     source: path
-    version: "4.0.0"
+    version: "4.4.1"
   serious_python_platform_interface:
     dependency: transitive
     description:
       path: "../../../serious_python_platform_interface"
       relative: true
     source: path
-    version: "4.0.0"
+    version: "4.4.1"
   serious_python_windows:
     dependency: transitive
     description:
       path: "../../../serious_python_windows"
       relative: true
     source: path
-    version: "4.0.0"
+    version: "4.4.1"
   shelf:
     dependency: transitive
     description:

--- a/src/serious_python/example/flask_example/pubspec.yaml
+++ b/src/serious_python/example/flask_example/pubspec.yaml
@@ -56,6 +56,15 @@ dev_dependencies:
 # following page: https://dart.dev/tools/pub/pubspec
 
 # The following section is specific to Flutter packages.
+# jni arrives transitively (path_provider -> path_provider_android ->
+# jni_flutter -> jni). 1.0.1 added global_jni_env.c, which passes a `va_list`
+# where a `void *` is expected: fine on x86_64, where va_list is an array type
+# that decays to a pointer, but a hard error on aarch64, where it's a struct.
+# That breaks `flutter build linux` on ARM64 hosts. Tracked upstream at
+# dart-lang/native#3498 — drop this override once a fixed jni is released.
+dependency_overrides:
+  jni: 1.0.0
+
 flutter:
 
   # The following line ensures that the Material Icons font is

--- a/src/serious_python/example/run_example/pubspec.lock
+++ b/src/serious_python/example/run_example/pubspec.lock
@@ -171,7 +171,7 @@ packages:
     source: sdk
     version: "0.0.0"
   jni:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: jni
       sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
@@ -384,42 +384,42 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "4.0.0"
+    version: "4.4.1"
   serious_python_android:
     dependency: transitive
     description:
       path: "../../../serious_python_android"
       relative: true
     source: path
-    version: "4.0.0"
+    version: "4.4.1"
   serious_python_darwin:
     dependency: transitive
     description:
       path: "../../../serious_python_darwin"
       relative: true
     source: path
-    version: "4.0.0"
+    version: "4.4.1"
   serious_python_linux:
     dependency: transitive
     description:
       path: "../../../serious_python_linux"
       relative: true
     source: path
-    version: "4.0.0"
+    version: "4.4.1"
   serious_python_platform_interface:
     dependency: transitive
     description:
       path: "../../../serious_python_platform_interface"
       relative: true
     source: path
-    version: "4.0.0"
+    version: "4.4.1"
   serious_python_windows:
     dependency: transitive
     description:
       path: "../../../serious_python_windows"
       relative: true
     source: path
-    version: "4.0.0"
+    version: "4.4.1"
   shelf:
     dependency: transitive
     description:

--- a/src/serious_python/example/run_example/pubspec.yaml
+++ b/src/serious_python/example/run_example/pubspec.yaml
@@ -58,6 +58,15 @@ dev_dependencies:
 # following page: https://dart.dev/tools/pub/pubspec
 
 # The following section is specific to Flutter packages.
+# jni arrives transitively (path_provider -> path_provider_android ->
+# jni_flutter -> jni). 1.0.1 added global_jni_env.c, which passes a `va_list`
+# where a `void *` is expected: fine on x86_64, where va_list is an array type
+# that decays to a pointer, but a hard error on aarch64, where it's a struct.
+# That breaks `flutter build linux` on ARM64 hosts. Tracked upstream at
+# dart-lang/native#3498 — drop this override once a fixed jni is released.
+dependency_overrides:
+  jni: 1.0.0
+
 flutter:
 
   # The following line ensures that the Material Icons font is


### PR DESCRIPTION
Unblocks CI. `Test Bridge example on Linux ARM64` has been failing on every recent PR with 19 copies of:

```
global_jni_env.c:284:68: error: passing 'va_list' (aka '__builtin_va_list')
                                to parameter of incompatible type 'void *'
```

## Root cause: upstream, not us

`jni` 1.0.1 was published **2026-07-27T01:10:21Z**. Last green ARM64 run was **Jul 25 22:23**; first failure **Jul 27 15:53**.

| | passing run (Jul 25) | failing run (Jul 27) |
| --- | --- | --- |
| resolved | `+ jni 1.0.0` | `+ jni 1.0.1` |
| `global_jni_env.c` | never compiled | 25 references, 19 errors |
| runner image | `ubuntu-24.04-arm 20260719.67.1` | identical |
| Flutter | `.fvmrc` 3.44.8 | identical |

1.0.1 added `global_jni_env.c`, which passes a `va_list` where a `void *` is expected. On x86_64 `va_list` is an array type that decays to a pointer, so it compiles; on aarch64 it's a struct, so it's a hard error. That's why **only** the ARM64 jobs fail — Android, Linux AMD64, Windows and the Apple jobs all pass.

Reported upstream: dart-lang/native#3498.

## Why it surfaced on a release PR

The examples depend on the serious_python packages by **path**. Bumping their version invalidates the committed `pubspec.lock`, so pub re-resolves the whole graph and takes the newest transitive versions — picking up `jni` 1.0.1. Any PR touching package versions after Jul 27 01:10Z would have hit this, and every future release PR will until it's pinned.

`jni` itself arrives via `path_provider` → `path_provider_android` → `jni_flutter` → `jni`.

## The fix

```yaml
dependency_overrides:
  jni: 1.0.0
```

`jni_flutter` 1.0.1 declares `jni: ^1.0.0`, so 1.0.0 satisfies it — this narrows within the allowed range rather than overriding a real constraint.

Applied to all three examples. Only `bridge_example` runs in CI, but the other two break identically for anyone building them on an ARM64 Linux host. Verified each resolves to `jni 1.0.0` after `flutter pub get`.

The `flask_example` / `run_example` locks also pick up the current path-dependency version (`4.0.0` → `4.4.1`) — they were simply stale.

Drop the override once a fixed `jni` ships.

## Note for #242

That PR branched from the same commit, so it needs `main` merged in after this lands to go green.

## This does not protect Flet users

`packages/flet` depends on `path_provider: ^2.1.5`, so a Flet app pulls `jni` through the same chain — and a generated Flet project has no committed lock, so it always resolves the newest. `flet build linux` on an ARM64 host will hit this. Fixing that needs a separate pin on the flet side, or the upstream fix.