### PR TITLE
fix: pass `--no-input` and bounded timeouts to `pip`

### DIFF
--- a/src/serious_python/CHANGELOG.md
+++ b/src/serious_python/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.5.2
+
+* **Packaging:** `pip install` no longer hangs when an index answers `401` — an authenticating mirror or proxy. pip prompted for credentials on a stdin nothing could answer, and wrote the prompt without a newline so callers never displayed it; the install blocked with `Looking in indexes: ...` as its last output, which `flet build` showed as a frozen `Packaging Python app...`. pip now runs with `--no-input` and bounded `--timeout`/`--retries`. See flet-dev/flet#5989, flet-dev/flet#5013 and flet-dev/flet#5507.
+
 ## 4.5.1
 
 * **iOS/macOS:** the bundled `Python`, `dart_bridge` and stdlib extension XCFrameworks are now signed on both layers — each slice's inner `.framework` as well as the outer `.xcframework`. 4.5.0 signed only the outer bundle. Note this did **not** change `isSecureTimestamp`, which still reports false — that field appears not to be reachable by signing; `signed`, which `ITMS-91065` names, is true. See `serious_python_darwin` 4.5.1.

--- a/src/serious_python/bin/package_command.dart
+++ b/src/serious_python/bin/package_command.dart
@@ -441,7 +441,16 @@ class PackageCommand extends Command {
             stdout.writeln(
                 "Installing $requirements with pip command to $sitePackagesDir");
 
-            List<String> pipArgs = ["--disable-pip-version-check"];
+            List<String> pipArgs = [
+              "--disable-pip-version-check",
+              // Without it, a 401 from an index makes pip prompt, and hang.
+              "--no-input",
+              // Bound each attempt instead of inheriting ambient pip config.
+              "--timeout",
+              "30",
+              "--retries",
+              "3",
+            ];
 
             if (isMobile || isWeb) {
               pipArgs.addAll(["--only-binary", ":all:"]);

--- a/src/serious_python/bin/package_command.dart
+++ b/src/serious_python/bin/package_command.dart
@@ -8,8 +8,8 @@ import 'package:glob/glob.dart';
 import 'package:glob/list_local_fs.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
-import 'package:shelf/shelf.dart';
 import 'package:serious_python/src/python_versions.dart';
+import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
 
 import 'macos_utils.dart' as macos_utils;
@@ -344,10 +344,8 @@ class PackageCommand extends Command {
       // site-packages root
       String sitePackagesRoot =
           path.join(currentPath, "build", "site-packages");
-      if (Platform.environment
-          .containsKey(sitePackagesEnvironmentVariable)) {
-        final envValue =
-            Platform.environment[sitePackagesEnvironmentVariable];
+      if (Platform.environment.containsKey(sitePackagesEnvironmentVariable)) {
+        final envValue = Platform.environment[sitePackagesEnvironmentVariable];
         if (envValue != null && envValue.isNotEmpty) {
           sitePackagesRoot = envValue;
         }
@@ -382,7 +380,8 @@ class PackageCommand extends Command {
           // minor (per python-build's manifest `android_abis`); installing
           // for an unpublished ABI would be wasted work.
           if (platform == "Android" &&
-              !pythonReleases[_pythonShortVersion]!.androidAbis
+              !pythonReleases[_pythonShortVersion]!
+                  .androidAbis
                   .contains(arch.key)) {
             continue;
           }
@@ -443,13 +442,12 @@ class PackageCommand extends Command {
 
             List<String> pipArgs = [
               "--disable-pip-version-check",
-              // Without it, a 401 from an index makes pip prompt, and hang.
-              "--no-input",
-              // Bound each attempt instead of inheriting ambient pip config.
               "--timeout",
               "30",
               "--retries",
               "3",
+              // Prevent pip from prompting and hanging for input.
+              "--no-input",
             ];
 
             if (isMobile || isWeb) {
@@ -685,7 +683,8 @@ class PackageCommand extends Command {
   Future<void> _stageDarwinSpm(String platform, String projectPath) async {
     final darwinDir = await _resolveDarwinDir(projectPath);
     if (darwinDir == null) {
-      stdout.writeln("SPM staging skipped: could not resolve serious_python_darwin "
+      stdout.writeln(
+          "SPM staging skipped: could not resolve serious_python_darwin "
           "(set $darwinDirEnvironmentVariable or ensure "
           ".dart_tool/package_config.json is present).");
       return;


### PR DESCRIPTION
## Problem

When an index answers `401` — a corporate mirror, an authenticating proxy — pip prompts for credentials. The `package` command starts pip with a stdin pipe that nothing writes to and nothing closes, so the prompt can never be answered, and pip blocks forever. `flet build` shows this as a frozen `Packaging Python app...` with no error, no progress and no timeout.

The prompt is also invisible: pip writes `User for <host>: ` to **stdout** with no trailing newline, and this command routes child stdout through `verbose()`, which `flet build` only enables at `-vv`. So the user gets a spinner and nothing else.

Reproduced against a local index returning `401 WWW-Authenticate: Basic`, driving the same pip the tool bundles (26.1.2, from the pinned python-build-standalone distro), with stdin held open the way `Process.start` leaves it:

```
as on main:     HUNG — killed at 30s | stdout=76B stderr=0B
                last output: "User for 127.0.0.1:52836: "
with this PR:   rc=1 in 1.2s | stdout=50B stderr=135B
                last output: "ERROR: No matching distribution found for foo"
```

## Change

`--no-input` makes pip fail with a readable error instead of prompting. `--timeout 30 --retries 3` pins the network bounds on the command line so they hold regardless of a user's `pip.conf` or `PIP_*` environment (CLI args win over both). pip's own defaults are 15 s / 5 retries, so this is not adding bounds where there were none — it is trading two retries for twice the patience per attempt, which suits the slow and throttled links these reports come from, and makes the worst case independent of ambient config.

Refs flet-dev/flet#5989, flet-dev/flet#5013, flet-dev/flet#5507.

## Scope

This closes one cause of the "packaging hangs" family, not all of them. Two things it deliberately does not cover:

- **A child that floods stderr still deadlocks.:* `runExec` drains only stdout while the child runs, so a chatty or failing wheel build wedges on the unread stderr pipe — ~1 KB is enough on Windows. That is the other half of flet-dev/flet#5507 and will be thought of separately.
- **Closing the child's stdin** is the complementary primitive. Worth noting the two interact: with stdin closed but no `--no-input`, pip dies with a **9.9 KB** `EOFError` traceback — which on Windows is itself large enough to wedge the undrained stderr pipe. `--no-input` is the better fix precisely because it never generates that output.
